### PR TITLE
Adds dedicated extension method per management endpoint

### DIFF
--- a/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
@@ -28,11 +28,57 @@ namespace Microsoft.AspNetCore.Builder
         public static void MapBffManagementEndpoints(
             this IEndpointRouteBuilder endpoints)
         {
+            endpoints.MapBffManagementLoginEndpoint();
+            endpoints.MapBffManagementLogoutEndpoint();
+            endpoints.MapBffManagementUserEndpoint();
+            endpoints.MapBffManagementBackchannelEndpoint();
+        }
+
+        /// <summary>
+        /// Adds the login BFF management endpoint
+        /// </summary>
+        /// <param name="endpoints"></param>
+        public static void MapBffManagementLoginEndpoint(
+            this IEndpointRouteBuilder endpoints)
+        {
             var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
 
             endpoints.MapGet(options.ManagementBasePath.Add("/login"), ProcessWith<ILoginService>);
+        }
+
+        /// <summary>
+        /// Adds the logout BFF management endpoint
+        /// </summary>
+        /// <param name="endpoints"></param>
+        public static void MapBffManagementLogoutEndpoint(
+            this IEndpointRouteBuilder endpoints)
+        {
+            var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
+
             endpoints.MapGet(options.ManagementBasePath.Add("/logout"), ProcessWith<ILogoutService>);
+        }
+
+        /// <summary>
+        /// Adds the user BFF management endpoint
+        /// </summary>
+        /// <param name="endpoints"></param>
+        public static void MapBffManagementUserEndpoint(
+            this IEndpointRouteBuilder endpoints)
+        {
+            var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
+
             endpoints.MapGet(options.ManagementBasePath.Add("/user"), ProcessWith<IUserService>);
+        }
+
+        /// <summary>
+        /// Adds the back channel BFF management endpoint
+        /// </summary>
+        /// <param name="endpoints"></param>
+        public static void MapBffManagementBackchannelEndpoint(
+            this IEndpointRouteBuilder endpoints)
+        {
+            var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
+
             endpoints.MapPost(options.ManagementBasePath.Add("/backchannel"), ProcessWith<IBackchannelLogoutService>);
         }
 


### PR DESCRIPTION
Adds dedicated extension methods per endpoint to have a more selective way of adding management endpoints

In our particular case, we challenge as soon as someone hits the page and only really need the logout endpoint.
This PR adds the possibility of just adding a particular management endpoint. 

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
