### PR TITLE
Sprinking passing of CancellationToken and IReadOnlyCollection instead of IEnumerable for collections returned.

### DIFF
--- a/src/Duende.Bff.EntityFramework/UserSessionStore.cs
+++ b/src/Duende.Bff.EntityFramework/UserSessionStore.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Duende.Bff.EntityFramework
@@ -30,23 +31,23 @@ namespace Duende.Bff.EntityFramework
         }
 
         /// <inheritdoc/>
-        public Task CreateUserSessionAsync(UserSession session)
+        public Task CreateUserSessionAsync(UserSession session, CancellationToken cancellationToken)
         {
             var item = new UserSessionEntity();
             session.CopyTo(item);
             _sessionDbContext.UserSessions.Add(item);
-            return _sessionDbContext.SaveChangesAsync();
+            return _sessionDbContext.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task DeleteUserSessionAsync(string key)
+        public async Task DeleteUserSessionAsync(string key, CancellationToken cancellationToken)
         {
-            var items = await _sessionDbContext.UserSessions.Where(x => x.Key == key).ToArrayAsync();
+            var items = await _sessionDbContext.UserSessions.Where(x => x.Key == key).ToArrayAsync(cancellationToken);
             var item = items.SingleOrDefault(x => x.Key == key);
             if (item != null)
             {
                 _sessionDbContext.UserSessions.Remove(item);
-                await _sessionDbContext.SaveChangesAsync();
+                await _sessionDbContext.SaveChangesAsync(cancellationToken);
             }
             else
             {
@@ -55,7 +56,7 @@ namespace Duende.Bff.EntityFramework
         }
 
         /// <inheritdoc/>
-        public async Task DeleteUserSessionsAsync(UserSessionsFilter filter)
+        public async Task DeleteUserSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken)
         {
             filter.Validate();
 
@@ -69,7 +70,7 @@ namespace Duende.Bff.EntityFramework
                 query = query.Where(x => x.SessionId == filter.SessionId);
             }
 
-            var items = await query.ToArrayAsync();
+            var items = await query.ToArrayAsync(cancellationToken);
             if (!String.IsNullOrWhiteSpace(filter.SubjectId))
             {
                 items = items.Where(x => x.SubjectId == filter.SubjectId).ToArray();
@@ -80,13 +81,13 @@ namespace Duende.Bff.EntityFramework
             }
 
             _sessionDbContext.RemoveRange(items);
-            await _sessionDbContext.SaveChangesAsync();
+            await _sessionDbContext.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<UserSession> GetUserSessionAsync(string key)
+        public async Task<UserSession> GetUserSessionAsync(string key, CancellationToken cancellationToken)
         {
-            var items = await _sessionDbContext.UserSessions.Where(x => x.Key == key).ToArrayAsync();
+            var items = await _sessionDbContext.UserSessions.Where(x => x.Key == key).ToArrayAsync(cancellationToken);
             var item = items.SingleOrDefault(x => x.Key == key);
             
             UserSession result = null;
@@ -104,7 +105,7 @@ namespace Duende.Bff.EntityFramework
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter)
+        public async Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken)
         {
             filter.Validate();
 
@@ -118,7 +119,7 @@ namespace Duende.Bff.EntityFramework
                 query = query.Where(x => x.SessionId == filter.SessionId);
             }
 
-            var items = await query.ToArrayAsync();
+            var items = await query.ToArrayAsync(cancellationToken);
             if (!String.IsNullOrWhiteSpace(filter.SubjectId))
             {
                 items = items.Where(x => x.SubjectId == filter.SubjectId).ToArray();
@@ -136,14 +137,14 @@ namespace Duende.Bff.EntityFramework
         }
 
         /// <inheritdoc/>
-        public async Task UpdateUserSessionAsync(string key, UserSessionUpdate session)
+        public async Task UpdateUserSessionAsync(string key, UserSessionUpdate session, CancellationToken cancellationToken)
         {
-            var items = await _sessionDbContext.UserSessions.Where(x => x.Key == key).ToArrayAsync();
+            var items = await _sessionDbContext.UserSessions.Where(x => x.Key == key).ToArrayAsync(cancellationToken);
             var item = items.SingleOrDefault(x => x.Key == key);
             if (item != null)
             {
                 session.CopyTo(item);
-                await _sessionDbContext.SaveChangesAsync();
+                await _sessionDbContext.SaveChangesAsync(cancellationToken);
             }
             else
             {

--- a/src/Duende.Bff/SessionManagement/ISessionRevocationService.cs
+++ b/src/Duende.Bff/SessionManagement/ISessionRevocationService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Duende.Bff
@@ -14,7 +15,8 @@ namespace Duende.Bff
         /// Revokes a user session
         /// </summary>
         /// <param name="filter"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task RevokeSessionsAsync(UserSessionsFilter filter);
+        Task RevokeSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Duende.Bff/SessionManagement/IUserSessionStore.cs
+++ b/src/Duende.Bff/SessionManagement/IUserSessionStore.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Duende.Bff
@@ -15,43 +16,49 @@ namespace Duende.Bff
         /// Retrieves a user session
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task<UserSession> GetUserSessionAsync(string key);
-        
+        Task<UserSession> GetUserSessionAsync(string key, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Creates a user session
         /// </summary>
         /// <param name="session"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task CreateUserSessionAsync(UserSession session);
+        Task CreateUserSessionAsync(UserSession session, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a user session
         /// </summary>
         /// <param name="key"></param>
         /// <param name="session"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task UpdateUserSessionAsync(string key, UserSessionUpdate session);
-        
+        Task UpdateUserSessionAsync(string key, UserSessionUpdate session, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Deletes a user session
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task DeleteUserSessionAsync(string key);
+        Task DeleteUserSessionAsync(string key, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Queries user sessions
         /// </summary>
         /// <param name="filter"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task<IEnumerable<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter);
+        Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a user session
         /// </summary>
         /// <param name="filter"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task DeleteUserSessionsAsync(UserSessionsFilter filter);
+        Task DeleteUserSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Duende.Bff/SessionManagement/NopSessionRevocationService.cs
+++ b/src/Duende.Bff/SessionManagement/NopSessionRevocationService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -23,7 +24,7 @@ namespace Duende.Bff
         }
         
         /// <inheritdoc />
-        public Task RevokeSessionsAsync(UserSessionsFilter filter)
+        public Task RevokeSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken = default)
         {
             _logger.LogDebug("Nop implementation of session revocation for sub: {sub}, and sid: {sid}. Implement ISessionRevocationService to provide your own implementation.", filter.SubjectId, filter.SessionId);
             return Task.CompletedTask;

--- a/src/Duende.Bff/SessionManagement/ServerSideTicketStore.cs
+++ b/src/Duende.Bff/SessionManagement/ServerSideTicketStore.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
@@ -19,8 +20,9 @@ namespace Duende.Bff
         /// Returns the AuthenticationTickets for the UserSessionsFilter.
         /// </summary>
         /// <param name="filter"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        Task<IEnumerable<AuthenticationTicket>> GetUserTicketsAsync(UserSessionsFilter filter);
+        Task<IReadOnlyCollection<AuthenticationTicket>> GetUserTicketsAsync(UserSessionsFilter filter, CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -103,12 +105,13 @@ namespace Duende.Bff
         /// Returns the AuthenticationTickets for the UserSessionsFilter.
         /// </summary>
         /// <param name="filter"></param>
+        /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
         /// <returns></returns>
-        public async Task<IEnumerable<AuthenticationTicket>> GetUserTicketsAsync(UserSessionsFilter filter)
+        public async Task<IReadOnlyCollection<AuthenticationTicket>> GetUserTicketsAsync(UserSessionsFilter filter, CancellationToken cancellationToken)
         {
             var list = new List<AuthenticationTicket>();
             
-            var sessions = await _store.GetUserSessionsAsync(filter);
+            var sessions = await _store.GetUserSessionsAsync(filter, cancellationToken);
             foreach(var session in sessions)
             {
                 var ticket = session.Deserialize();

--- a/src/Duende.Bff/SessionManagement/SessionRevocationService.cs
+++ b/src/Duende.Bff/SessionManagement/SessionRevocationService.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Duende.Bff
@@ -39,7 +40,7 @@ namespace Duende.Bff
         }
 
         /// <inheritdoc/>
-        public async Task RevokeSessionsAsync(UserSessionsFilter filter)
+        public async Task RevokeSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken = default)
         {
             if (_options.BackchannelLogoutAllUserSessions)
             {

--- a/test/Duende.Bff.Tests/TestFramework/MockSessionRevocationService.cs
+++ b/test/Duende.Bff.Tests/TestFramework/MockSessionRevocationService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Duende.Bff.Tests.TestFramework
@@ -9,7 +10,7 @@ namespace Duende.Bff.Tests.TestFramework
     {
         public bool DeleteUserSessionsWasCalled { get; set; }
         public UserSessionsFilter DeleteUserSessionsFilter { get; set; }
-        public Task RevokeSessionsAsync(UserSessionsFilter filter)
+        public Task RevokeSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken)
         {
             DeleteUserSessionsWasCalled = true;
             DeleteUserSessionsFilter = filter;


### PR DESCRIPTION
**What issue does this PR address?**

- Add CancellationToken to various store interfaces.
- Passes cancellation token to subsequent async methods calls. However some external async interfaces (i.e. ITicketStore) don't support accepting a cancellation token. https://github.com/dotnet/aspnetcore/issues/32443
- When returning a collection use `IReadOnlyCollection<T>` instead of `IEnumerable<T>` as the latter implies deferred exception but we require the implementer to return a materialized collection. (Alternatively, if deferred execution is desirable, then one should use IAsyncEnumerable instead).

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
