### PR TITLE
Fixed registration of server side session store

### DIFF
--- a/src/Duende.Bff/BffBuilder.cs
+++ b/src/Duende.Bff/BffBuilder.cs
@@ -37,11 +37,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns></returns>
         public BffBuilder AddServerSideSessions()
         {
-            Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureApplicationCookieTicketStore>();
-            Services.AddTransient<IServerTicketStore, ServerSideTicketStore>();
-            Services.AddTransient<ISessionRevocationService, SessionRevocationService>();
-
-            Services.TryAddSingleton<IUserSessionStore, InMemoryUserSessionStore>();
+            AddServerSideSessions<InMemoryUserSessionStore>();
 
             return this;
         }
@@ -54,8 +50,10 @@ namespace Microsoft.AspNetCore.Builder
         public BffBuilder AddServerSideSessions<T>()
             where T : class, IUserSessionStore
         {
-            AddServerSideSessions();
-            Services.AddTransient<IUserSessionStore, T>();
+            Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureApplicationCookieTicketStore>();
+            Services.AddTransient<IServerTicketStore, ServerSideTicketStore>();
+            Services.AddTransient<ISessionRevocationService, SessionRevocationService>();
+            Services.TryAddSingleton<IUserSessionStore, T>();
 
             return this;
         }


### PR DESCRIPTION
Im currently working on a distributed cache implementation of IUserSessionStore and stumbled over the changed lines of code

If I understand this right, a custom session store would be registered as transient but should be singleton.
I also moved the other registrations over to the generic method, to avoid a unused DI registration of InMemoryUserSessionStore