### PR TITLE
Dom/net6

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
+++ b/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
@@ -50,18 +50,20 @@ namespace Duende.Bff.Yarp
                 string token = null;
                 if (metadata.RequiredTokenType.HasValue)
                 {
-                    UserAccessTokenParameters paramsCopied = new UserAccessTokenParameters();
+                    var userAccessTokenParameters = new UserAccessTokenParameters();
 
-                    if (metadata.BffUserAccessTokenParameters != null && !string.IsNullOrEmpty(metadata.BffUserAccessTokenParameters.SignInScheme))
+                    if (metadata.BffUserAccessTokenParameters != null)
                     {
-                        paramsCopied.Resource = metadata.BffUserAccessTokenParameters.Resource;
-                        paramsCopied.SignInScheme = metadata.BffUserAccessTokenParameters.SignInScheme;
-                        paramsCopied.ForceRenewal = metadata.BffUserAccessTokenParameters.ForceRenewal;
+                        userAccessTokenParameters = metadata.BffUserAccessTokenParameters.ToUserAccessTokenParameters();
 
-                        var result = await context.AuthenticateAsync(metadata.BffUserAccessTokenParameters.SignInScheme);
-                        if (result.Properties != null && result.Properties.Items.TryGetValue(AuthSchemeKey, out var authenticatedScheme))
+                        if (userAccessTokenParameters.SignInScheme != null)
                         {
-                            paramsCopied.ChallengeScheme = authenticatedScheme;
+                            var result = await context.AuthenticateAsync(userAccessTokenParameters.SignInScheme);
+                            if (result.Properties != null &&
+                                result.Properties.Items.TryGetValue(AuthSchemeKey, out var authenticatedScheme))
+                            {
+                                userAccessTokenParameters.ChallengeScheme = authenticatedScheme;
+                            }
                         }
                     }
 

--- a/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
+++ b/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
@@ -50,24 +50,24 @@ namespace Duende.Bff.Yarp
                 string token = null;
                 if (metadata.RequiredTokenType.HasValue)
                 {
-                    var userAccessTokenParameters = new UserAccessTokenParameters();
+                    var toUserAccessTokenParameters = new UserAccessTokenParameters();
 
                     if (metadata.BffUserAccessTokenParameters != null)
                     {
-                        userAccessTokenParameters = metadata.BffUserAccessTokenParameters.ToUserAccessTokenParameters();
+                        toUserAccessTokenParameters = metadata.BffUserAccessTokenParameters.ToUserAccessTokenParameters();
 
-                        if (userAccessTokenParameters.SignInScheme != null)
+                        if (toUserAccessTokenParameters.SignInScheme != null)
                         {
-                            var result = await context.AuthenticateAsync(userAccessTokenParameters.SignInScheme);
+                            var result = await context.AuthenticateAsync(toUserAccessTokenParameters.SignInScheme);
                             if (result.Properties != null &&
                                 result.Properties.Items.TryGetValue(AuthSchemeKey, out var authenticatedScheme))
                             {
-                                userAccessTokenParameters.ChallengeScheme = authenticatedScheme;
+                                toUserAccessTokenParameters.ChallengeScheme = authenticatedScheme;
                             }
                         }
                     }
 
-                    token = await context.GetManagedAccessToken(metadata.RequiredTokenType.Value, paramsCopied);
+                    token = await context.GetManagedAccessToken(metadata.RequiredTokenType.Value, toUserAccessTokenParameters);
                     if (string.IsNullOrWhiteSpace(token))
                     {
                         logger.AccessTokenMissing(localPath, metadata.RequiredTokenType.Value);

--- a/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
+++ b/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
@@ -4,6 +4,7 @@
 using System;
 using Duende.Bff.Logging;
 using Duende.Bff.Yarp.Logging;
+using IdentityModel.AspNetCore.AccessTokenManagement;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,9 +25,10 @@ namespace Duende.Bff.Yarp
         /// </summary>
         /// <param name="localPath">The local path (e.g. /api)</param>
         /// <param name="apiAddress">The remote address (e.g. https://api.myapp.com/foo)</param>
+        /// <param name="userAccessTokenParameters"></param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public static RequestDelegate Map(string localPath, string apiAddress)
+        public static RequestDelegate Map(string localPath, string apiAddress, UserAccessTokenParameters userAccessTokenParameters = null)
         {
             return async context =>
             {

--- a/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
+++ b/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
@@ -68,7 +68,7 @@ namespace Duende.Bff.Yarp
                 {
                     if (metadata.OptionalUserToken)
                     {
-                        token = await context.GetUserAccessTokenAsync();
+                        token = await context.GetUserAccessTokenAsync(toUserAccessTokenParameters);
                     }
                 }
 

--- a/src/Duende.Bff/BffServiceCollectionExtensions.cs
+++ b/src/Duende.Bff/BffServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             var opts = new BffOptions();
             configureAction?.Invoke(opts);
-            services.AddSingleton(opts);
+            services.AddSingleton(opts);                                  
 
             services.AddAccessTokenManagement();
             

--- a/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using Duende.Bff.Endpoints;
+using IdentityModel.AspNetCore.AccessTokenManagement;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Builder

--- a/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Builder
     public static class BffEndpointRouteBuilderExtensions
     {
         internal static bool _licenseChecked;
-        
+
         private static Task ProcessWith<T>(HttpContext context)
             where T : IBffEndpointService
         {

--- a/src/Duende.Bff/Endpoints/BffRemoteApiEndpointExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffRemoteApiEndpointExtensions.cs
@@ -49,5 +49,25 @@ namespace Microsoft.AspNetCore.Builder
 
             return builder;
         }
+
+        /// <summary>
+        /// Allows for setting a UserAccessTokenParameter
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="bffUserAccessTokenParameters"></param>
+        /// <typeparam name="TBuilder"></typeparam>
+        /// <returns></returns>
+        public static TBuilder WithUserAccessTokenParameter<TBuilder>(this TBuilder builder, BffUserAccessTokenParameters bffUserAccessTokenParameters) where TBuilder : IEndpointConventionBuilder
+        {
+            builder.Add(endpointBuilder =>
+            {
+                var metadata =
+                    endpointBuilder.Metadata.First(m => m.GetType() == typeof(BffRemoteApiEndpointMetadata)) as BffRemoteApiEndpointMetadata;
+
+                metadata.BffUserAccessTokenParameters = bffUserAccessTokenParameters;
+            });
+
+            return builder;
+        }
     }
 }

--- a/src/Duende.Bff/Endpoints/BffRemoteApiEndpointMetadata.cs
+++ b/src/Duende.Bff/Endpoints/BffRemoteApiEndpointMetadata.cs
@@ -22,5 +22,10 @@ namespace Duende.Bff
         /// Require presence of anti-forgery header
         /// </summary>
         public bool RequireAntiForgeryHeader { get; set; } = true;
+
+        /// <summary>
+        /// Maps to UserAccessTokenParameters and included if set
+        /// </summary>
+        public BffUserAccessTokenParameters BffUserAccessTokenParameters { get; set; }
     }
 }

--- a/src/Duende.Bff/Endpoints/BffUserAccessTokenParameters.cs
+++ b/src/Duende.Bff/Endpoints/BffUserAccessTokenParameters.cs
@@ -1,60 +1,62 @@
 using IdentityModel.AspNetCore.AccessTokenManagement;
 
-namespace Duende.Bff;
-
-/// <summary>
-/// Additional optional parameters for a user access token request
-/// </summary>
-public class BffUserAccessTokenParameters
+namespace Duende.Bff
 {
     /// <summary>
-    /// All properties are private with the sole intention being the transfer to a UserAccessTokenParameters via ToUserAccessTokenParameters
+    /// Additional optional parameters for a user access token request
     /// </summary>
-    /// <param name="signInScheme"></param>
-    /// <param name="challengeScheme"></param>
-    /// <param name="forceRenewal"></param>
-    /// <param name="resource"></param>
-    public BffUserAccessTokenParameters(string signInScheme = null, string challengeScheme = null, bool forceRenewal = false, string resource = null)
+    public class BffUserAccessTokenParameters
     {
-        SignInScheme = signInScheme;
-        ChallengeScheme = challengeScheme;
-        ForceRenewal = forceRenewal;
-        Resource = resource;
-    }
-
-    /// <summary>
-    /// Overrides the default sign-in scheme. This information may be used for state management.
-    /// </summary>
-    private string SignInScheme { get; }
-
-    /// <summary>
-    /// Overrides the default challenge scheme. This information may be used for deriving token service configuration.
-    /// </summary>
-    private string ChallengeScheme { get; }
-
-    /// <summary>
-    /// Force renewal of token.
-    /// </summary>
-    private bool ForceRenewal { get; }
-
-    /// <summary>
-    /// Specifies the resource parameter.
-    /// </summary>
-    private string Resource { get; }
-
-    /// <summary>
-    /// Retrieve a UserAccessTokenParameters
-    /// </summary>
-    /// <returns></returns>
-    public UserAccessTokenParameters ToUserAccessTokenParameters()
-    {
-        return new UserAccessTokenParameters()
+        /// <summary>
+        /// All properties are private with the sole intention being the transfer to a UserAccessTokenParameters via ToUserAccessTokenParameters
+        /// </summary>
+        /// <param name="signInScheme"></param>
+        /// <param name="challengeScheme"></param>
+        /// <param name="forceRenewal"></param>
+        /// <param name="resource"></param>
+        public BffUserAccessTokenParameters(string signInScheme = null, string challengeScheme = null,
+            bool forceRenewal = false, string resource = null)
         {
-            SignInScheme = this.SignInScheme,
-            ChallengeScheme = this.ChallengeScheme,
-            ForceRenewal = this.ForceRenewal,
-            Resource = this.Resource
-        };
+            SignInScheme = signInScheme;
+            ChallengeScheme = challengeScheme;
+            ForceRenewal = forceRenewal;
+            Resource = resource;
+        }
 
+        /// <summary>
+        /// Overrides the default sign-in scheme. This information may be used for state management.
+        /// </summary>
+        private string SignInScheme { get; }
+
+        /// <summary>
+        /// Overrides the default challenge scheme. This information may be used for deriving token service configuration.
+        /// </summary>
+        private string ChallengeScheme { get; }
+
+        /// <summary>
+        /// Force renewal of token.
+        /// </summary>
+        private bool ForceRenewal { get; }
+
+        /// <summary>
+        /// Specifies the resource parameter.
+        /// </summary>
+        private string Resource { get; }
+
+        /// <summary>
+        /// Retrieve a UserAccessTokenParameters
+        /// </summary>
+        /// <returns></returns>
+        public UserAccessTokenParameters ToUserAccessTokenParameters()
+        {
+            return new UserAccessTokenParameters()
+            {
+                SignInScheme = this.SignInScheme,
+                ChallengeScheme = this.ChallengeScheme,
+                ForceRenewal = this.ForceRenewal,
+                Resource = this.Resource
+            };
+
+        }
     }
 }

--- a/src/Duende.Bff/Endpoints/BffUserAccessTokenParameters.cs
+++ b/src/Duende.Bff/Endpoints/BffUserAccessTokenParameters.cs
@@ -1,0 +1,37 @@
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Additional optional parameters for a user access token request
+    /// </summary>
+    public class BffUserAccessTokenParameters
+    {
+        public BffUserAccessTokenParameters(string signInScheme = null, string challengeScheme = null,
+            bool forceRenewal = false, string resource = null)
+        {
+            SignInScheme = signInScheme;
+            ChallengeScheme = challengeScheme;
+            ForceRenewal = forceRenewal;
+            Resource = resource;
+        }
+
+        /// <summary>
+        /// Overrides the default sign-in scheme. This information may be used for state management.
+        /// </summary>
+        public string SignInScheme { get; }
+
+        /// <summary>
+        /// Overrides the default challenge scheme. This information may be used for deriving token service configuration.
+        /// </summary>
+        public string ChallengeScheme { get; }
+
+        /// <summary>
+        /// Force renewal of token.
+        /// </summary>
+        public bool ForceRenewal { get; }
+
+        /// <summary>
+        /// Specifies the resource parameter.
+        /// </summary>
+        public string Resource { get; set; }
+    }
+}

--- a/src/Duende.Bff/Endpoints/BffUserAccessTokenParameters.cs
+++ b/src/Duende.Bff/Endpoints/BffUserAccessTokenParameters.cs
@@ -1,37 +1,60 @@
-namespace Duende.Bff
+using IdentityModel.AspNetCore.AccessTokenManagement;
+
+namespace Duende.Bff;
+
+/// <summary>
+/// Additional optional parameters for a user access token request
+/// </summary>
+public class BffUserAccessTokenParameters
 {
     /// <summary>
-    /// Additional optional parameters for a user access token request
+    /// All properties are private with the sole intention being the transfer to a UserAccessTokenParameters via ToUserAccessTokenParameters
     /// </summary>
-    public class BffUserAccessTokenParameters
+    /// <param name="signInScheme"></param>
+    /// <param name="challengeScheme"></param>
+    /// <param name="forceRenewal"></param>
+    /// <param name="resource"></param>
+    public BffUserAccessTokenParameters(string signInScheme = null, string challengeScheme = null, bool forceRenewal = false, string resource = null)
     {
-        public BffUserAccessTokenParameters(string signInScheme = null, string challengeScheme = null,
-            bool forceRenewal = false, string resource = null)
+        SignInScheme = signInScheme;
+        ChallengeScheme = challengeScheme;
+        ForceRenewal = forceRenewal;
+        Resource = resource;
+    }
+
+    /// <summary>
+    /// Overrides the default sign-in scheme. This information may be used for state management.
+    /// </summary>
+    private string SignInScheme { get; }
+
+    /// <summary>
+    /// Overrides the default challenge scheme. This information may be used for deriving token service configuration.
+    /// </summary>
+    private string ChallengeScheme { get; }
+
+    /// <summary>
+    /// Force renewal of token.
+    /// </summary>
+    private bool ForceRenewal { get; }
+
+    /// <summary>
+    /// Specifies the resource parameter.
+    /// </summary>
+    private string Resource { get; }
+
+    /// <summary>
+    /// Retrieve a UserAccessTokenParameters
+    /// </summary>
+    /// <returns></returns>
+    public UserAccessTokenParameters ToUserAccessTokenParameters()
+    {
+        return new UserAccessTokenParameters()
         {
-            SignInScheme = signInScheme;
-            ChallengeScheme = challengeScheme;
-            ForceRenewal = forceRenewal;
-            Resource = resource;
-        }
+            SignInScheme = this.SignInScheme,
+            ChallengeScheme = this.ChallengeScheme,
+            ForceRenewal = this.ForceRenewal,
+            Resource = this.Resource
+        };
 
-        /// <summary>
-        /// Overrides the default sign-in scheme. This information may be used for state management.
-        /// </summary>
-        public string SignInScheme { get; }
-
-        /// <summary>
-        /// Overrides the default challenge scheme. This information may be used for deriving token service configuration.
-        /// </summary>
-        public string ChallengeScheme { get; }
-
-        /// <summary>
-        /// Force renewal of token.
-        /// </summary>
-        public bool ForceRenewal { get; }
-
-        /// <summary>
-        /// Specifies the resource parameter.
-        /// </summary>
-        public string Resource { get; set; }
     }
 }

--- a/src/Duende.Bff/Extensions.cs
+++ b/src/Duende.Bff/Extensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using IdentityModel.AspNetCore.AccessTokenManagement;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 
@@ -30,13 +31,13 @@ namespace Duende.Bff
             return antiForgeryHeader != null && antiForgeryHeader == options.AntiForgeryHeaderValue;
         }
 
-        public static async Task<string> GetManagedAccessToken(this HttpContext context, TokenType tokenType)
+        public static async Task<string> GetManagedAccessToken(this HttpContext context, TokenType tokenType, UserAccessTokenParameters userAccessTokenParameters = null)
         {
             string token;
 
             if (tokenType == TokenType.User)
             {
-                token = await context.GetUserAccessTokenAsync();
+                token = await context.GetUserAccessTokenAsync(userAccessTokenParameters);
             }
             else if (tokenType == TokenType.Client)
             {
@@ -44,7 +45,7 @@ namespace Duende.Bff
             }
             else
             {
-                token = await context.GetUserAccessTokenAsync();
+                token = await context.GetUserAccessTokenAsync(userAccessTokenParameters);
 
                 if (string.IsNullOrEmpty(token))
                 {

--- a/test/Duende.Bff.Tests/TestHosts/BffHost.cs
+++ b/test/Duende.Bff.Tests/TestHosts/BffHost.cs
@@ -14,11 +14,8 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using CsQuery.Implementation;
 using Duende.Bff.Yarp;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Duende.Bff.Tests.TestHosts
 {
@@ -108,7 +105,7 @@ namespace Duende.Bff.Tests.TestHosts
                 options.AddPolicy("AlwaysFail", policy => { policy.RequireAssertion(ctx => false); });
             });
         }
-        
+
         private void Configure(IApplicationBuilder app)
         {
             if (_useForwardedHeaders)

--- a/test/Duende.Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
+++ b/test/Duende.Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
@@ -22,7 +22,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Duende.Bff.Tests.TestHosts
 {
-    public class BffHost : GenericHost
+    public class BffHostUsingResourceNamedTokens : GenericHost
     {
         public int? LocalApiStatusCodeToReturn { get; set; }
 
@@ -33,7 +33,7 @@ namespace Duende.Bff.Tests.TestHosts
 
         public BffOptions BffOptions { get; set; } = new();
 
-        public BffHost(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
+        public BffHostUsingResourceNamedTokens(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
             string baseAddress = "https://app", bool useForwardedHeaders = false)
             : base(baseAddress)
         {
@@ -77,6 +77,11 @@ namespace Duende.Bff.Tests.TestHosts
                 })
                 .AddOpenIdConnect("oidc", options =>
                 {
+                    options.Events.OnUserInformationReceived = async context =>
+                    {
+                        await StoreNamedTokensAsync((context.ProtocolMessage.AccessToken, context.ProtocolMessage.RefreshToken), context.Properties, context.ProtocolMessage.IdToken);
+                    };
+
                     options.Authority = _identityServerHost.Url();
 
                     options.ClientId = _clientId;
@@ -108,7 +113,14 @@ namespace Duende.Bff.Tests.TestHosts
                 options.AddPolicy("AlwaysFail", policy => { policy.RequireAssertion(ctx => false); });
             });
         }
-        
+
+        public static async Task StoreNamedTokensAsync((string accessToken, string refreshToken) userTokens, AuthenticationProperties authenticationProperties, string identityToken = null)
+        {
+            var tokens = new List<AuthenticationToken>();
+            tokens.Add(new AuthenticationToken { Name = $"{OpenIdConnectParameterNames.AccessToken}::named_token_stored", Value = userTokens.accessToken });
+            authenticationProperties.StoreTokens(tokens);
+        }
+
         private void Configure(IApplicationBuilder app)
         {
             if (_useForwardedHeaders)
@@ -132,184 +144,15 @@ namespace Duende.Bff.Tests.TestHosts
             {
                 endpoints.MapBffManagementEndpoints();
 
-                endpoints.Map("/local_anon", async context =>
-                    {
-                        // capture body if present
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
-
-                        // capture request headers
-                        var requestHeaders = new Dictionary<string, List<string>>();
-                        foreach (var header in context.Request.Headers)
-                        {
-                            var values = new List<string>(header.Value.Select(v => v));
-                            requestHeaders.Add(header.Key, values);
-                        }
-
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            context.User.FindFirst(("sub"))?.Value,
-                            context.User.FindFirst(("client_id"))?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body,
-                            RequestHeaders = requestHeaders
-                        };
-
-                        context.Response.StatusCode = LocalApiStatusCodeToReturn ?? 200;
-                        LocalApiStatusCodeToReturn = null;
-
-                        context.Response.ContentType = "application/json";
-                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                    })
-                    .AsBffApiEndpoint();
-                
-                endpoints.Map("/local_anon_no_csrf", async context =>
-                    {
-                        // capture body if present
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
-
-                        // capture request headers
-                        var requestHeaders = new Dictionary<string, List<string>>();
-                        foreach (var header in context.Request.Headers)
-                        {
-                            var values = new List<string>(header.Value.Select(v => v));
-                            requestHeaders.Add(header.Key, values);
-                        }
-
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            context.User.FindFirst(("sub"))?.Value,
-                            context.User.FindFirst(("client_id"))?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body,
-                            RequestHeaders = requestHeaders
-                        };
-
-                        context.Response.StatusCode = LocalApiStatusCodeToReturn ?? 200;
-                        LocalApiStatusCodeToReturn = null;
-
-                        context.Response.ContentType = "application/json";
-                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                    })
-                    .AsBffApiEndpoint(requireAntiForgeryCheck: false);
-
-                endpoints.Map("/local_authz", async context =>
-                    {
-                        var sub = context.User.FindFirst(("sub"))?.Value;
-                        if (sub == null) throw new Exception("sub is missing");
-
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
-
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            sub,
-                            context.User.FindFirst(("client_id"))?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body
-                        };
-
-                        context.Response.StatusCode = LocalApiStatusCodeToReturn ?? 200;
-                        LocalApiStatusCodeToReturn = null;
-
-                        context.Response.ContentType = "application/json";
-                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                    })
-                    .RequireAuthorization()
-                    .AsBffApiEndpoint();
-
-                endpoints.Map("/local_authz_no_csrf", async context =>
-                    {
-                        var sub = context.User.FindFirst(("sub"))?.Value;
-                        if (sub == null) throw new Exception("sub is missing");
-
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
-
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            sub,
-                            context.User.FindFirst(("client_id"))?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body
-                        };
-
-                        context.Response.StatusCode = LocalApiStatusCodeToReturn ?? 200;
-                        LocalApiStatusCodeToReturn = null;
-
-                        context.Response.ContentType = "application/json";
-                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                    })
-                    .RequireAuthorization()
-                    .AsBffApiEndpoint(requireAntiForgeryCheck: false);
-
-
-                endpoints.Map("/always_fail_authz_non_bff_endpoint", context => { return Task.CompletedTask; })
-                    .RequireAuthorization("AlwaysFail");
-
-                endpoints.Map("/always_fail_authz", context => { return Task.CompletedTask; })
-                    .AsBffApiEndpoint()
-                    .RequireAuthorization("AlwaysFail");
-
                 endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user", _apiHost.Url())
+                        "/api_user_with_useraccesstokenparameters_having_stored_named_token", _apiHost.Url())
+                    .WithUserAccessTokenParameter(new BffUserAccessTokenParameters("cookie", null, true, "named_token_stored"))
                     .RequireAccessToken();
 
                 endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user_no_csrf", _apiHost.Url(), requireAntiForgeryCheck: false)
+                        "/api_user_with_useraccesstokenparameters_having_not_stored_named_token", _apiHost.Url())
+                    .WithUserAccessTokenParameter(new BffUserAccessTokenParameters("cookie", null, true, "named_token_not_stored"))
                     .RequireAccessToken();
-
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_client", _apiHost.Url())
-                    .RequireAccessToken(TokenType.Client);
-
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user_or_client", _apiHost.Url())
-                    .RequireAccessToken(TokenType.UserOrClient);
-
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user_or_anon", _apiHost.Url())
-                    .WithOptionalUserAccessToken();
-
-                endpoints.MapRemoteBffApiEndpoint(
-                    "/api_anon_only", _apiHost.Url());
-
-                endpoints.Map(
-                    "/not_bff_endpoint", 
-                    RemoteApiEndpoint.Map("/not_bff_endpoint", _apiHost.Url()));
             });
 
             app.Map("/invalid_endpoint",

--- a/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
+++ b/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
@@ -15,6 +15,7 @@ namespace Duende.Bff.Tests.TestHosts
         protected readonly IdentityServerHost IdentityServerHost;
         protected ApiHost ApiHost;
         protected BffHost BffHost;
+        protected BffHostUsingResourceNamedTokens BffHostWithNamedTokens;
 
         public BffIntegrationTestBase()
         {
@@ -57,6 +58,9 @@ namespace Duende.Bff.Tests.TestHosts
 
             BffHost = new BffHost(IdentityServerHost, ApiHost, "spa");
             BffHost.InitializeAsync().Wait();
+
+            BffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(IdentityServerHost, ApiHost, "spa");
+            BffHostWithNamedTokens.InitializeAsync().Wait();
         }
 
         public async Task Login(string sub)


### PR DESCRIPTION
**Extend to allow passing UserAccessTokenParameters to GetUserAccessTokenAsync**

Motivation is to allow for the use of Duende.Bff in a project requiring the use of multiple authentication schemes, and storage of multiple API-specific tokens.

UserAccessTokenParameters are already exposed on: Assembly IdentityModel.AspNetCore, TokenManagementHttpContextExtensions

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
