### PR TITLE
Add diagnostics endpoint

### DIFF
--- a/src/Duende.Bff/BffOptions.cs
+++ b/src/Duende.Bff/BffOptions.cs
@@ -63,17 +63,25 @@ namespace Duende.Bff
         /// Login endpoint
         /// </summary>
         public PathString LoginPath => ManagementBasePath.Add(Constants.ManagementEndpoints.Login);
+        
         /// <summary>
         /// Logout endpoint
         /// </summary>
         public PathString LogoutPath => ManagementBasePath.Add(Constants.ManagementEndpoints.Logout);
+        
         /// <summary>
         /// User endpoint
         /// </summary>
         public PathString UserPath => ManagementBasePath.Add(Constants.ManagementEndpoints.User);
+        
         /// <summary>
         /// Back channel logout endpoint
         /// </summary>
         public PathString BackChannelLogoutPath => ManagementBasePath.Add(Constants.ManagementEndpoints.BackChannelLogout);
+        
+        /// <summary>
+        /// Diagnostics endpoint
+        /// </summary>
+        public PathString DiagnosticsPath => ManagementBasePath.Add(Constants.ManagementEndpoints.Diagnostics);
     }
 }

--- a/src/Duende.Bff/BffServiceCollectionExtensions.cs
+++ b/src/Duende.Bff/BffServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Builder
             services.AddTransient<ILogoutService, DefaultLogoutService>();
             services.AddTransient<IUserService, DefaultUserService>();
             services.AddTransient<IBackchannelLogoutService, DefaultBackchannelLogoutService>();
+            services.AddTransient<IDiagnosticsService, DefaultDiagnosticsService>();
             
             // session management
             services.TryAddTransient<ISessionRevocationService, NopSessionRevocationService>();

--- a/src/Duende.Bff/Constants.cs
+++ b/src/Duende.Bff/Constants.cs
@@ -67,7 +67,7 @@ namespace Duende.Bff
             /// <summary>
             /// Diagnostics path
             /// </summary>
-            public const string Diagnostics = "/diag";
+            public const string Diagnostics = "/diagnostics";
         }
 
         /// <summary>

--- a/src/Duende.Bff/Constants.cs
+++ b/src/Duende.Bff/Constants.cs
@@ -48,18 +48,26 @@ namespace Duende.Bff
             /// Login path
             /// </summary>
             public const string Login = "/login";
+            
             /// <summary>
             /// Logout path
             /// </summary>
             public const string Logout = "/logout";
+            
             /// <summary>
             /// User path
             /// </summary>
             public const string User = "/user";
+            
             /// <summary>
             /// Back channel logout path
             /// </summary>
             public const string BackChannelLogout = "/backchannel";
+            
+            /// <summary>
+            /// Diagnostics path
+            /// </summary>
+            public const string Diagnostics = "/diag";
         }
 
         /// <summary>

--- a/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Builder
             endpoints.MapBffManagementLogoutEndpoint();
             endpoints.MapBffManagementUserEndpoint();
             endpoints.MapBffManagementBackchannelEndpoint();
+            endpoints.MapBffDiagnosticsEndpoint();
         }
 
         /// <summary>
@@ -89,6 +90,19 @@ namespace Microsoft.AspNetCore.Builder
             var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
 
             endpoints.MapPost(options.BackChannelLogoutPath, ProcessWith<IBackchannelLogoutService>);
+        }
+        
+        /// <summary>
+        /// Adds the logout BFF management endpoint
+        /// </summary>
+        /// <param name="endpoints"></param>
+        public static void MapBffDiagnosticsEndpoint(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.CheckLicense();
+            
+            var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
+
+            endpoints.MapGet(options.DiagnosticsPath, ProcessWith<IDiagnosticsService>);
         }
         
         internal static void CheckLicense(this IEndpointRouteBuilder endpoints)

--- a/src/Duende.Bff/Endpoints/DefaultDiagnosticsService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultDiagnosticsService.cs
@@ -2,6 +2,7 @@
 // // See LICENSE in the project root for license information.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
@@ -17,11 +18,16 @@ namespace Duende.Bff
     {
         private readonly IWebHostEnvironment _environment;
 
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="environment"></param>
         public DefaultDiagnosticsService(IWebHostEnvironment environment)
         {
             _environment = environment;
         }
         
+        /// <inheritdoc />
         public async Task ProcessRequestAsync(HttpContext context)
         {
             if (!_environment.IsDevelopment())
@@ -38,8 +44,20 @@ namespace Duende.Bff
                 UserAccessToken = usertoken,
                 ClientAccessToken = clientToken
             };
+            
+#if NET6_0_OR_GREATER
+            var options = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+#else
+            var options = new JsonSerializerOptions
+            {
+                IgnoreNullValues = true
+            };
+#endif
 
-            var json = JsonSerializer.Serialize(info, new JsonSerializerOptions { IgnoreNullValues = true });
+            var json = JsonSerializer.Serialize(info, options);
 
             context.Response.ContentType = "application/json";
             await context.Response.WriteAsync(json);

--- a/src/Duende.Bff/Endpoints/DefaultDiagnosticsService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultDiagnosticsService.cs
@@ -1,0 +1,54 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Default debug diagnostics service
+    /// </summary>
+    public class DefaultDiagnosticsService : IDiagnosticsService
+    {
+        private readonly IWebHostEnvironment _environment;
+
+        public DefaultDiagnosticsService(IWebHostEnvironment environment)
+        {
+            _environment = environment;
+        }
+        
+        public async Task ProcessRequestAsync(HttpContext context)
+        {
+            if (!_environment.IsDevelopment())
+            {
+                context.Response.StatusCode = 404;
+                return;
+            }
+
+            var usertoken = await context.GetUserAccessTokenAsync();
+            var clientToken = await context.GetClientAccessTokenAsync();
+
+            var info = new DiagnosticsInfo
+            {
+                UserAccessToken = usertoken,
+                ClientAccessToken = clientToken
+            };
+
+            var json = JsonSerializer.Serialize(info, new JsonSerializerOptions { IgnoreNullValues = true });
+
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(json);
+        }
+
+        private class DiagnosticsInfo
+        {
+            public string UserAccessToken { get; set; }
+            public string ClientAccessToken { get; set; }
+        }
+    }
+}

--- a/src/Duende.Bff/Endpoints/IDiagnosticsService.cs
+++ b/src/Duende.Bff/Endpoints/IDiagnosticsService.cs
@@ -1,0 +1,12 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Service for handling debug diagnostics
+    /// </summary>
+    public interface IDiagnosticsService : IBffEndpointService
+    {
+    }
+}


### PR DESCRIPTION
Adds a diagnostics endpoint that allows copying the current tokens for manual testing.

Only enabled in dev mode.