### PR TITLE
Always update the sub and sid in the server ticket store when renewing cookie

### DIFF
--- a/src/Duende.Bff/SessionManagement/UserSession.cs
+++ b/src/Duende.Bff/SessionManagement/UserSession.cs
@@ -16,21 +16,6 @@ namespace Duende.Bff
         public string Key { get; set; }
 
         /// <summary>
-        /// The subject ID
-        /// </summary>
-        public string SubjectId { get; set; }
-        
-        /// <summary>
-        /// The session ID
-        /// </summary>
-        public string SessionId { get; set; }
-        
-        /// <summary>
-        /// The creation time
-        /// </summary>
-        public DateTime Created { get; set; }
-        
-        /// <summary>
         /// Clones the instance
         /// </summary>
         /// <returns></returns>
@@ -49,12 +34,7 @@ namespace Duende.Bff
         public void CopyTo(UserSession other)
         {
             other.Key = Key;
-            other.SubjectId = SubjectId;
-            other.SessionId = SessionId;
-            other.Created = Created;
-            other.Renewed = Renewed;
-            other.Expires = Expires;
-            other.Ticket = Ticket;
+            base.CopyTo(other);
         }
     }
 }

--- a/src/Duende.Bff/SessionManagement/UserSessionUpdate.cs
+++ b/src/Duende.Bff/SessionManagement/UserSessionUpdate.cs
@@ -11,6 +11,21 @@ namespace Duende.Bff
     public class UserSessionUpdate
     {
         /// <summary>
+        /// The subject ID
+        /// </summary>
+        public string SubjectId { get; set; }
+
+        /// <summary>
+        /// The session ID
+        /// </summary>
+        public string SessionId { get; set; }
+
+        /// <summary>
+        /// The creation time
+        /// </summary>
+        public DateTime Created { get; set; }
+        
+        /// <summary>
         /// The renewal time
         /// </summary>
         public DateTime Renewed { get; set; }
@@ -32,6 +47,9 @@ namespace Duende.Bff
         /// <returns></returns>
         public void CopyTo(UserSessionUpdate other)
         {
+            other.SubjectId = SubjectId;
+            other.SessionId = SessionId;
+            other.Created = Created;
             other.Renewed = Renewed;
             other.Expires = Expires;
             other.Ticket = Ticket;

--- a/test/Duende.Bff.EntityFramework.Tests/UserSessionStoreTests.cs
+++ b/test/Duende.Bff.EntityFramework.Tests/UserSessionStoreTests.cs
@@ -95,21 +95,48 @@ namespace Duende.Bff.EntityFramework.Tests
                 Ticket = "ticket"
             });
 
-            await _subject.UpdateUserSessionAsync("key123", new UserSessionUpdate {
-                Ticket = "ticket2",
-                Renewed = new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc),
-                Expires = new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc)
-            });
+            {
+                await _subject.UpdateUserSessionAsync("key123", new UserSessionUpdate
+                {
+                    Ticket = "ticket2",
+                    SessionId = "sid",
+                    SubjectId = "sub",
+                    Created = new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc),
+                    Renewed = new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc),
+                    Expires = new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc)
+                });
 
-            var item = await _subject.GetUserSessionAsync("key123");
-            item.Should().NotBeNull();
-            item.Key.Should().Be("key123");
-            item.SubjectId.Should().Be("sub");
-            item.SessionId.Should().Be("sid");
-            item.Ticket.Should().Be("ticket2");
-            item.Created.Should().Be(new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc));
-            item.Renewed.Should().Be(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
-            item.Expires.Should().Be(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
+                var item = await _subject.GetUserSessionAsync("key123");
+                item.Should().NotBeNull();
+                item.Key.Should().Be("key123");
+                item.SubjectId.Should().Be("sub");
+                item.SessionId.Should().Be("sid");
+                item.Ticket.Should().Be("ticket2");
+                item.Created.Should().Be(new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc));
+                item.Renewed.Should().Be(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
+                item.Expires.Should().Be(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
+            }
+            {
+                await _subject.UpdateUserSessionAsync("key123", new UserSessionUpdate
+                {
+                    Ticket = "ticket3",
+                    SessionId = "sid2",
+                    SubjectId = "sub2",
+                    Created = new DateTime(2022, 3, 1, 9, 12, 33, DateTimeKind.Utc),
+                    Renewed = new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc),
+                    Expires = new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc)
+                });
+
+                var item = await _subject.GetUserSessionAsync("key123");
+                item.Should().NotBeNull();
+                item.Key.Should().Be("key123");
+                item.SubjectId.Should().Be("sub2");
+                item.SessionId.Should().Be("sid2");
+                item.Ticket.Should().Be("ticket3");
+                item.Created.Should().Be(new DateTime(2022, 3, 1, 9, 12, 33, DateTimeKind.Utc));
+                item.Renewed.Should().Be(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
+                item.Expires.Should().Be(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
+            }
         }
         [Fact]
         public async Task UpdateUserSessionAsync_for_invalid_key_should_succeed()


### PR DESCRIPTION
When the server-side ticket store renews a ticket/cookie our BFF implementation checks if the subject id and session id in the store is the same as the current ticket being renewed. If not, the implementation throws. 

It turns out there are some scenarios where the new ticket can be a different subject or session, mainly because the ASP.NET Core cookie authentication handler will re-use the ticket key even if the new cookie is for a different subject or session.

This PR relaxes this check to allow for these edge cases.

Fixes: https://github.com/DuendeSoftware/BFF/issues/60

***Note:***
This is technically a breaking change. The `UserSessionUpdate` class passed to `IUserSessionStore.UpdateUserSessionAsync` now has new properties: `SubjectId`, `SessionId`, and `Created` which were previously only used in `CreateUserSessionAsync`. 

If you implement a custom `IUserSessionStore` and you use our `CopyTo` helpers, you are **not affected** by the breaking change. 

If you implement a custom `IUserSessionStore` and you do not use our `CopyTo` helpers, you **are affected** by the breaking change.
