### PR TITLE
Add lightweight checksession / login check

### DIFF
--- a/samples/JS6/Startup.cs
+++ b/samples/JS6/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using Duende.Bff;
 using Duende.Bff.Yarp;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/JS6/wwwroot/StyleSheet.css
+++ b/samples/JS6/wwwroot/StyleSheet.css
@@ -1,3 +1,7 @@
 ﻿pre:empty {
     display: none;
 }
+
+iframe {
+    display:none;
+}

--- a/samples/JS6/wwwroot/app.js
+++ b/samples/JS6/wwwroot/app.js
@@ -140,7 +140,7 @@ function silentLogin(iframeSelector) {
     return new Promise((resolve, reject) => {
         function onMessage(e) {
             // look for messages sent from the BFF iframe
-            if (e.data && e.data.source === 'bff-silent-login') {
+            if (e.data && e.data['source'] === 'bff-silent-login') {
                 window.removeEventListener("message", onMessage);
                 // send along the boolean result
                 resolve(e.data.isLoggedIn);
@@ -155,10 +155,10 @@ function silentLogin(iframeSelector) {
         window.setTimeout(() => {
             window.removeEventListener("message", onMessage);
 
-            // so we can either just treat this like a "not logged in"
+            // we can either just treat this like a "not logged in"
             resolve(false);
             // or we can trigger an error, so someone can look into the reason why
-            //reject(new Error("timed_out")); 
+            // reject(new Error("timed_out")); 
         }, timeout);
 
         // send the iframe to the silent login endpoint to kick off the workflow

--- a/samples/JS6/wwwroot/app.js
+++ b/samples/JS6/wwwroot/app.js
@@ -25,6 +25,16 @@ async function onLoad() {
             }
         } else if (resp.status === 401) {
             log("user not logged in");
+
+            window.addEventListener("message", e => {
+                if (e.data.source === 'bff-silent-login') {
+                    if (e.data.isLoggedIn) {
+                        window.location.reload();
+                    }
+                }
+            });
+
+            document.querySelector("#silent").src = "/bff/silent-login";
         }
     }
     catch (e) {
@@ -115,3 +125,4 @@ function log() {
         document.getElementById('response').innerText += msg + '\r\n';
     });
 }
+

--- a/samples/JS6/wwwroot/app.js
+++ b/samples/JS6/wwwroot/app.js
@@ -1,4 +1,5 @@
 ﻿const loginUrl = "/bff/login";
+const silentLoginUrl = "/bff/silent-login";
 const userUrl = "/bff/user";
 const localApiUrl = "/local";
 const remoteApiUrl = "/api";
@@ -26,15 +27,24 @@ async function onLoad() {
         } else if (resp.status === 401) {
             log("user not logged in");
 
-            window.addEventListener("message", e => {
-                if (e.data.source === 'bff-silent-login') {
-                    if (e.data.isLoggedIn) {
+            // if we've detected that the user is no already logged in, we can attempt a silent login
+            // this will trigger a normal OIDC request in an iframe using prompt=none.
+            // if the user is already logged into IdentityServer, then the result will establish a session in the BFF.
+            // this whole process avoids redirecting the top window without knowing if the user is logged in or not.
+            silentSignin()
+                .then(result => {
+                    // the result is a boolean letting us know if the user has been logged in silently
+                    log("silent login result: " + result);
+
+                    if (result) {
+                        // if we now have a user logged in silently, then reload this window
                         window.location.reload();
                     }
-                }
-            });
-
-            document.querySelector("#silent").src = "/bff/silent-login";
+                })
+                .catch(err => {
+                    // error on this should be a rare, and usually due to a config or coding mistake
+                    log("silent login error", err);
+                });
         }
     }
     catch (e) {
@@ -126,3 +136,37 @@ function log() {
     });
 }
 
+
+// this will trigger the silent login and return a promise that resolves to true or false.
+function silentSignin(iframeSelector) {
+    iframeSelector = iframeSelector || "#bff-silent-login";
+    const timeout = 5000;
+
+    return new Promise((resolve, reject) => {
+        function onMessage(e) {
+            // look for messages sent from the BFF iframe
+            if (e.data && e.data.source === 'bff-silent-login') {
+                window.removeEventListener("message", onMessage);
+                // send along the boolean result
+                resolve(e.data.isLoggedIn);
+            }
+        };
+
+        // listen for the iframe response to notify its parent (i.e. this window).
+        window.addEventListener("message", onMessage);
+
+        // we're setting up a time to handle scenarios when the iframe doesn't return immediaetly (despite prompt=none).
+        // this likely means the iframe is showing the error page at IdentityServer (typically due to client misconfiguration).
+        window.setTimeout(() => {
+            window.removeEventListener("message", onMessage);
+
+            // so we can either just treat this like a "not logged in"
+            resolve(false);
+            // or we can trigger an error, so someone can look into the reason why
+            //reject(new Error("timed_out")); 
+        }, timeout);
+
+        // send the iframe to the silent login endpoint to kick off the workflow
+        document.querySelector(iframeSelector).src = silentLoginUrl;
+    });
+}

--- a/samples/JS6/wwwroot/app.js
+++ b/samples/JS6/wwwroot/app.js
@@ -31,20 +31,15 @@ async function onLoad() {
             // this will trigger a normal OIDC request in an iframe using prompt=none.
             // if the user is already logged into IdentityServer, then the result will establish a session in the BFF.
             // this whole process avoids redirecting the top window without knowing if the user is logged in or not.
-            silentSignin()
-                .then(result => {
-                    // the result is a boolean letting us know if the user has been logged in silently
-                    log("silent login result: " + result);
+            var silentLoginResult = await silentLogin();
 
-                    if (result) {
-                        // if we now have a user logged in silently, then reload this window
-                        window.location.reload();
-                    }
-                })
-                .catch(err => {
-                    // error on this should be a rare, and usually due to a config or coding mistake
-                    log("silent login error", err);
-                });
+            // the result is a boolean letting us know if the user has been logged in silently
+            log("silent login result: " + silentLoginResult);
+
+            if (silentLoginResult) {
+                // if we now have a user logged in silently, then reload this window
+                window.location.reload();
+            }
         }
     }
     catch (e) {
@@ -138,7 +133,7 @@ function log() {
 
 
 // this will trigger the silent login and return a promise that resolves to true or false.
-function silentSignin(iframeSelector) {
+function silentLogin(iframeSelector) {
     iframeSelector = iframeSelector || "#bff-silent-login";
     const timeout = 5000;
 

--- a/samples/JS6/wwwroot/index.html
+++ b/samples/JS6/wwwroot/index.html
@@ -58,5 +58,7 @@
     </div>
     
     <script src="app.js"></script>
+
+    <iframe id="silent"></iframe>
 </body>
 </html>

--- a/samples/JS6/wwwroot/index.html
+++ b/samples/JS6/wwwroot/index.html
@@ -59,6 +59,6 @@
     
     <script src="app.js"></script>
 
-    <iframe id="silent"></iframe>
+    <iframe id="bff-silent-login"></iframe>
 </body>
 </html>

--- a/src/Duende.Bff/BffOpenIdConnectEvents.cs
+++ b/src/Duende.Bff/BffOpenIdConnectEvents.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// BFF specific OpenIdConnectEvents class.
+    /// </summary>
+    public class BffOpenIdConnectEvents : OpenIdConnectEvents
+    {
+        /// <summary>
+        /// The logger.
+        /// </summary>
+        protected readonly ILogger<BffOpenIdConnectEvents> Logger;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="logger"></param>
+        public BffOpenIdConnectEvents(ILogger<BffOpenIdConnectEvents> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public override async Task RedirectToIdentityProvider(RedirectContext context)
+        {
+            if (!await ProcessRedirectToIdentityProviderAsync(context))
+            {
+                await base.RedirectToIdentityProvider(context);
+            }
+        }
+
+        /// <summary>
+        /// Processes the RedirectToIdentityProvider event.
+        /// </summary>
+        public virtual Task<bool> ProcessRedirectToIdentityProviderAsync(RedirectContext context)
+        {
+            if (context.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+            {
+                Logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login");
+                context.ProtocolMessage.Prompt = "none";
+            }
+
+            // we've not "handled" the request, so let other code process
+            return Task.FromResult(false);
+        }
+
+        /// <inheritdoc/>
+        public override async Task MessageReceived(MessageReceivedContext context)
+        {
+            if (!await ProcessMessageReceivedAsync(context))
+            {
+                await base.MessageReceived(context);
+            }
+        }
+
+        /// <summary>
+        /// Processes the MessageReceived event.
+        /// </summary>
+        public virtual Task<bool> ProcessMessageReceivedAsync(MessageReceivedContext context)
+        {
+            if (context.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin) &&
+                            context.Properties.RedirectUri != null)
+            {
+                context.HttpContext.Items[Constants.BffFlags.SilentLogin] = context.Properties.RedirectUri;
+
+                if (context.ProtocolMessage.Error != null)
+                {
+                    Logger.LogDebug("Handling error response from OIDC provider for BFF silent login.");
+
+                    context.HandleResponse();
+                    context.Response.Redirect(context.Properties.RedirectUri);
+                    return Task.FromResult(true);
+                }
+            }
+
+            return Task.FromResult(false);
+        }
+
+        /// <inheritdoc/>
+        public override async Task AuthenticationFailed(AuthenticationFailedContext context)
+        {
+            if (!await ProcessAuthenticationFailedAsync(context))
+            {
+                await base.AuthenticationFailed(context);
+            }
+        }
+
+        /// <summary>
+        /// Processes the AuthenticationFailed event.
+        /// </summary>
+        public virtual Task<bool> ProcessAuthenticationFailedAsync(AuthenticationFailedContext context)
+        {
+            if (context.HttpContext.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+            {
+                Logger.LogDebug("Handling failed response from OIDC provider for BFF silent login.");
+
+                context.HandleResponse();
+                context.Response.Redirect(context.HttpContext.Items[Constants.BffFlags.SilentLogin]!.ToString()!);
+
+                return Task.FromResult(true);
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Duende.Bff/BffOpenIdConnectEvents.cs
+++ b/src/Duende.Bff/BffOpenIdConnectEvents.cs
@@ -40,7 +40,7 @@ namespace Duende.Bff
         /// </summary>
         public virtual Task<bool> ProcessRedirectToIdentityProviderAsync(RedirectContext context)
         {
-            if (context.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+            if (context.Properties?.IsSilentLogin() == true)
             {
                 Logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login");
                 context.ProtocolMessage.Prompt = "none";
@@ -64,8 +64,8 @@ namespace Duende.Bff
         /// </summary>
         public virtual Task<bool> ProcessMessageReceivedAsync(MessageReceivedContext context)
         {
-            if (context.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin) &&
-                            context.Properties.RedirectUri != null)
+            if (context.Properties?.IsSilentLogin() == true &&
+                context.Properties?.RedirectUri != null)
             {
                 context.HttpContext.Items[Constants.BffFlags.SilentLogin] = context.Properties.RedirectUri;
 

--- a/src/Duende.Bff/BffOptions.cs
+++ b/src/Duende.Bff/BffOptions.cs
@@ -57,12 +57,22 @@ namespace Duende.Bff
         /// License key
         /// </summary>
         public string? LicenseKey { get; set; }
-        
+
         /// <summary>
         /// Login endpoint
         /// </summary>
         public PathString LoginPath => ManagementBasePath.Add(Constants.ManagementEndpoints.Login);
+
+        /// <summary>
+        /// Silent login endpoint
+        /// </summary>
+        public PathString SilentLoginPath => ManagementBasePath.Add(Constants.ManagementEndpoints.SilentLogin);
         
+        /// <summary>
+        /// Silent login callback endpoint
+        /// </summary>
+        public PathString SilentLoginCallbackPath => ManagementBasePath.Add(Constants.ManagementEndpoints.SilentLoginCallback);
+
         /// <summary>
         /// Logout endpoint
         /// </summary>

--- a/src/Duende.Bff/BffServiceCollectionExtensions.cs
+++ b/src/Duende.Bff/BffServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using System;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -29,9 +30,11 @@ namespace Microsoft.AspNetCore.Builder
             services.AddSingleton(opts);                                  
 
             services.AddAccessTokenManagement();
-            
+
             // management endpoints
             services.AddTransient<ILoginService, DefaultLoginService>();
+            services.AddTransient<ISilentLoginService, DefaultSilentLoginService>();
+            services.AddTransient<ISilentLoginCallbackService, DefaultSilentLoginCallbackService>();
             services.AddTransient<ILogoutService, DefaultLogoutService>();
             services.AddTransient<IUserService, DefaultUserService>();
             services.AddTransient<IBackchannelLogoutService, DefaultBackchannelLogoutService>();
@@ -45,13 +48,14 @@ namespace Microsoft.AspNetCore.Builder
             services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureSlidingExpirationCheck>();
             #else
             services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureApplicationValidatePrincipal>();
-            #endif
-            
-            services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureApplicationCookieRevokeRefreshToken>();
+#endif
 
-            #if NET5_0_OR_GREATER
+            services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureApplicationCookieRevokeRefreshToken>();
+            services.AddSingleton<IPostConfigureOptions<OpenIdConnectOptions>, PostConfigureOidcOptionsForSilentLogin>();
+
+#if NET5_0_OR_GREATER
             services.AddTransient<IAuthorizationMiddlewareResultHandler, BffAuthorizationMiddlewareResultHandler>();
-            #endif
+#endif
 
             return new BffBuilder(services);
         }

--- a/src/Duende.Bff/Constants.cs
+++ b/src/Duende.Bff/Constants.cs
@@ -53,7 +53,17 @@ namespace Duende.Bff
             /// Login path
             /// </summary>
             public const string Login = "/login";
+
+            /// <summary>
+            /// Silent login path
+            /// </summary>
+            public const string SilentLogin = "/silent-login";
             
+            /// <summary>
+            /// Silent login callback path
+            /// </summary>
+            public const string SilentLoginCallback = "/silent-login-callback";
+
             /// <summary>
             /// Logout path
             /// </summary>
@@ -89,6 +99,18 @@ namespace Duende.Bff
             /// Used to pass a return URL to login/logout
             /// </summary>
             public const string ReturnUrl = "returnUrl";
+        }
+
+
+        /// <summary>
+        /// Internal flags for library behavior
+        /// </summary>
+        public static class BffFlags
+        {
+            /// <summary>
+            /// Used to indicate the OIDC request is a silent login
+            /// </summary>
+            public const string SilentLogin = "bff-silent-login";
         }
     }
 }

--- a/src/Duende.Bff/Endpoints/AuthenticationPropertiesExtensions.cs
+++ b/src/Duende.Bff/Endpoints/AuthenticationPropertiesExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Duende.Bff
+{
+    /// <summary>
+    ///  Extension methods for AuthenticationProperties
+    /// </summary>
+    public static class AuthenticationPropertiesExtensions
+    {
+        /// <summary>
+        /// Determines if this AuthenticationProperties represents a BFF silent login.
+        /// </summary>
+        public static bool IsSilentLogin(this AuthenticationProperties props)
+        {
+            return props.Items.ContainsKey(Constants.BffFlags.SilentLogin);
+        }
+    }
+}

--- a/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.Builder
         public static void MapBffManagementEndpoints(this IEndpointRouteBuilder endpoints)
         {
             endpoints.MapBffManagementLoginEndpoint();
+            endpoints.MapBffManagementSilentLoginEndpoints();
             endpoints.MapBffManagementLogoutEndpoint();
             endpoints.MapBffManagementUserEndpoint();
             endpoints.MapBffManagementBackchannelEndpoint();
@@ -49,6 +50,20 @@ namespace Microsoft.AspNetCore.Builder
             var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
 
             endpoints.MapGet(options.LoginPath, ProcessWith<ILoginService>);
+        }
+
+        /// <summary>
+        /// Adds the silent login BFF management endpoints
+        /// </summary>
+        /// <param name="endpoints"></param>
+        public static void MapBffManagementSilentLoginEndpoints(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.CheckLicense();
+
+            var options = endpoints.ServiceProvider.GetRequiredService<BffOptions>();
+
+            endpoints.MapGet(options.SilentLoginPath, ProcessWith<ISilentLoginService>);
+            endpoints.MapGet(options.SilentLoginCallbackPath, ProcessWith<ISilentLoginCallbackService>);
         }
 
         /// <summary>

--- a/src/Duende.Bff/Endpoints/DefaultSilentLoginCallbackService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultSilentLoginCallbackService.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using IdentityModel;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Service for handling silent login callback requests
+    /// </summary>
+    public class DefaultSilentLoginCallbackService : ISilentLoginCallbackService
+    {
+        private readonly BffOptions _options;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="options"></param>
+        public DefaultSilentLoginCallbackService(BffOptions options)
+        {
+            _options = options;
+        }
+
+        /// <inheritdoc />
+        public async Task ProcessRequestAsync(HttpContext context)
+        {
+            context.CheckForBffMiddleware(_options);
+
+            var result = (await context.AuthenticateAsync()).Succeeded ? "true" : "false";
+            var json = $"{{source:'bff-silent-login', isLoggedIn:{result}}}";
+            var nonce = CryptoRandom.CreateUniqueId(format:CryptoRandom.OutputFormat.Hex);
+            var origin = $"{context.Request.Scheme}://{context.Request.Host}";
+            var html = $"<script nonce='{nonce}'>window.parent.postMessage({json}, '{origin}');</script>";
+
+            context.Response.StatusCode = 200;
+            context.Response.ContentType = "text/html";
+            context.Response.Headers.Add("Content-Security-Policy", $"script-src 'nonce-{nonce}';");
+            
+            if (!context.Response.Headers.ContainsKey("Cache-Control"))
+            {
+                context.Response.Headers.Add("Cache-Control", "no-store, no-cache, max-age=0");
+            }
+            else
+            {
+                context.Response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
+            }
+            if (!context.Response.Headers.ContainsKey("Pragma"))
+            {
+                context.Response.Headers.Add("Pragma", "no-cache");
+            }
+            
+            await context.Response.WriteAsync(html, Encoding.UTF8);
+        }
+    }
+}

--- a/src/Duende.Bff/Endpoints/DefaultSilentLoginCallbackService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultSilentLoginCallbackService.cs
@@ -32,27 +32,19 @@ namespace Duende.Bff
 
             var result = (await context.AuthenticateAsync()).Succeeded ? "true" : "false";
             var json = $"{{source:'bff-silent-login', isLoggedIn:{result}}}";
+            
             var nonce = CryptoRandom.CreateUniqueId(format:CryptoRandom.OutputFormat.Hex);
             var origin = $"{context.Request.Scheme}://{context.Request.Host}";
+            
             var html = $"<script nonce='{nonce}'>window.parent.postMessage({json}, '{origin}');</script>";
 
             context.Response.StatusCode = 200;
             context.Response.ContentType = "text/html";
-            context.Response.Headers.Add("Content-Security-Policy", $"script-src 'nonce-{nonce}';");
             
-            if (!context.Response.Headers.ContainsKey("Cache-Control"))
-            {
-                context.Response.Headers.Add("Cache-Control", "no-store, no-cache, max-age=0");
-            }
-            else
-            {
-                context.Response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
-            }
-            if (!context.Response.Headers.ContainsKey("Pragma"))
-            {
-                context.Response.Headers.Add("Pragma", "no-cache");
-            }
-            
+            context.Response.Headers["Content-Security-Policy"] = $"script-src 'nonce-{nonce}';";
+            context.Response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
+            context.Response.Headers["Pragma"] = "no-cache";
+
             await context.Response.WriteAsync(html, Encoding.UTF8);
         }
     }

--- a/src/Duende.Bff/Endpoints/DefaultSilentLoginService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultSilentLoginService.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Service for handling silent login requests
+    /// </summary>
+    public class DefaultSilentLoginService : ISilentLoginService
+    {
+        private readonly BffOptions _options;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="options"></param>
+        public DefaultSilentLoginService(BffOptions options)
+        {
+            _options = options;
+        }
+        
+        /// <inheritdoc />
+        public async Task ProcessRequestAsync(HttpContext context)
+        {
+            context.CheckForBffMiddleware(_options);
+
+            var props = new AuthenticationProperties
+            {
+                RedirectUri = _options.SilentLoginCallbackPath,
+                Items =
+                {
+                    { Constants.BffFlags.SilentLogin, "true" }
+                },
+            };
+
+            await context.ChallengeAsync(props);
+        }
+    }
+}

--- a/src/Duende.Bff/Endpoints/ISilentLoginCallbackService.cs
+++ b/src/Duende.Bff/Endpoints/ISilentLoginCallbackService.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Service for handling silent login callback requests
+    /// </summary>
+    public interface ISilentLoginCallbackService : IBffEndpointService
+    {
+    }
+}

--- a/src/Duende.Bff/Endpoints/ISilentLoginService.cs
+++ b/src/Duende.Bff/Endpoints/ISilentLoginService.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// Service for handling silent login requests
+    /// </summary>
+    public interface ISilentLoginService : IBffEndpointService
+    {
+    }
+}

--- a/src/Duende.Bff/PostConfigureOidcOptionsForSilentLogin.cs
+++ b/src/Duende.Bff/PostConfigureOidcOptionsForSilentLogin.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -15,44 +14,34 @@ namespace Duende.Bff
     /// </summary>
     public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<OpenIdConnectOptions>
     {
-        private readonly string? _scheme;
-        private readonly ILogger<PostConfigureOidcOptionsForSilentLogin> _logger;
+        private readonly BffOpenIdConnectEvents _events;
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="authenticationSchemeProvider"></param>
-        /// <param name="logger"></param>
-        public PostConfigureOidcOptionsForSilentLogin(IAuthenticationSchemeProvider authenticationSchemeProvider, ILogger<PostConfigureOidcOptionsForSilentLogin> logger)
+        public PostConfigureOidcOptionsForSilentLogin(ILoggerFactory logger)
         {
-            _scheme = authenticationSchemeProvider.GetDefaultChallengeSchemeAsync().Result?.Name;
-            _logger = logger;
+            _events = new BffOpenIdConnectEvents(logger.CreateLogger<BffOpenIdConnectEvents>());
         }
 
         /// <inheritdoc />
         public void PostConfigure(string name, OpenIdConnectOptions options)
         {
-            if (name == _scheme)
-            {
-                options.Events.OnRedirectToIdentityProvider = CreateRedirectCallback(options.Events.OnRedirectToIdentityProvider);
-                options.Events.OnMessageReceived = CreateMessageReceivedCallback(options.Events.OnMessageReceived);
-                options.Events.OnAuthenticationFailed = CreateAuthenticationFailedCallback(options.Events.OnAuthenticationFailed);
-            }
+            options.Events.OnRedirectToIdentityProvider = CreateRedirectCallback(options.Events.OnRedirectToIdentityProvider);
+            options.Events.OnMessageReceived = CreateMessageReceivedCallback(options.Events.OnMessageReceived);
+            options.Events.OnAuthenticationFailed = CreateAuthenticationFailedCallback(options.Events.OnAuthenticationFailed);
         }
 
         private Func<RedirectContext, Task> CreateRedirectCallback(Func<RedirectContext, Task> inner)
         {
             async Task Callback(RedirectContext ctx)
             {
-                if (ctx.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+                if (!await _events.ProcessRedirectToIdentityProviderAsync(ctx))
                 {
-                    _logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login");
-                    ctx.ProtocolMessage.Prompt = "none";
-                }
-
-                if (inner != null)
-                {
-                    await inner.Invoke(ctx);
+                    if (inner != null)
+                    {
+                        await inner.Invoke(ctx);
+                    }
                 }
             };
 
@@ -63,23 +52,12 @@ namespace Duende.Bff
         {
             async Task Callback(MessageReceivedContext ctx)
             {
-                if (ctx.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin) &&
-                    ctx.Properties.RedirectUri != null)
+                if (!await _events.ProcessMessageReceivedAsync(ctx))
                 {
-                    ctx.HttpContext.Items[Constants.BffFlags.SilentLogin] = ctx.Properties.RedirectUri;
-
-                    if (ctx.ProtocolMessage.Error != null)
+                    if (inner != null)
                     {
-                        _logger.LogDebug("Handling error response from OIDC provider for BFF silent login.");
-                        ctx.HandleResponse();
-                        ctx.Response.Redirect(ctx.Properties.RedirectUri);
-                        return;
+                        await inner.Invoke(ctx);
                     }
-                }
-
-                if (inner != null)
-                {
-                    await inner.Invoke(ctx);
                 }
             };
 
@@ -90,17 +68,12 @@ namespace Duende.Bff
         {
             async Task Callback(AuthenticationFailedContext ctx)
             {
-                if (ctx.HttpContext.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+                if (!await _events.ProcessAuthenticationFailedAsync(ctx))
                 {
-                    _logger.LogDebug("Handling failed response from OIDC provider for BFF silent login.");
-                    ctx.HandleResponse();
-                    ctx.Response.Redirect(ctx.HttpContext.Items[Constants.BffFlags.SilentLogin]!.ToString()!);
-                    return;
-                }
-
-                if (inner != null)
-                {
-                    await inner.Invoke(ctx);
+                    if (inner != null)
+                    {
+                        await inner.Invoke(ctx);
+                    }
                 }
             };
 

--- a/src/Duende.Bff/PostConfigureOidcOptionsForSilentLogin.cs
+++ b/src/Duende.Bff/PostConfigureOidcOptionsForSilentLogin.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -14,22 +15,35 @@ namespace Duende.Bff
     /// </summary>
     public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<OpenIdConnectOptions>
     {
+        private readonly string? _scheme;
         private readonly BffOpenIdConnectEvents _events;
 
         /// <summary>
         /// ctor
         /// </summary>
-        public PostConfigureOidcOptionsForSilentLogin(ILoggerFactory logger)
+        public PostConfigureOidcOptionsForSilentLogin(IOptions<AuthenticationOptions> options, ILoggerFactory logger)
         {
+            _scheme = options.Value.DefaultChallengeScheme;
             _events = new BffOpenIdConnectEvents(logger.CreateLogger<BffOpenIdConnectEvents>());
         }
 
         /// <inheritdoc />
         public void PostConfigure(string name, OpenIdConnectOptions options)
         {
-            options.Events.OnRedirectToIdentityProvider = CreateRedirectCallback(options.Events.OnRedirectToIdentityProvider);
-            options.Events.OnMessageReceived = CreateMessageReceivedCallback(options.Events.OnMessageReceived);
-            options.Events.OnAuthenticationFailed = CreateAuthenticationFailedCallback(options.Events.OnAuthenticationFailed);
+            if (_scheme == name)
+            {
+                if (options.EventsType != null && !typeof(BffOpenIdConnectEvents).IsAssignableFrom(options.EventsType))
+                {
+                    throw new Exception("EventsType on OpenIdConnectOptions must derive from BffOpenIdConnectEvents to work with the BFF framework.");
+                }
+
+                if (options.EventsType == null)
+                {
+                    options.Events.OnRedirectToIdentityProvider = CreateRedirectCallback(options.Events.OnRedirectToIdentityProvider);
+                    options.Events.OnMessageReceived = CreateMessageReceivedCallback(options.Events.OnMessageReceived);
+                    options.Events.OnAuthenticationFailed = CreateAuthenticationFailedCallback(options.Events.OnAuthenticationFailed);
+                }
+            }
         }
 
         private Func<RedirectContext, Task> CreateRedirectCallback(Func<RedirectContext, Task> inner)

--- a/src/Duende.Bff/PostConfigureOidcOptionsForSilentLogin.cs
+++ b/src/Duende.Bff/PostConfigureOidcOptionsForSilentLogin.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Threading.Tasks;
+
+namespace Duende.Bff
+{
+    /// <summary>
+    /// OIDC configuration to add silent login support
+    /// </summary>
+    public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<OpenIdConnectOptions>
+    {
+        private readonly string? _scheme;
+        private readonly ILogger<PostConfigureOidcOptionsForSilentLogin> _logger;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="authenticationSchemeProvider"></param>
+        /// <param name="logger"></param>
+        public PostConfigureOidcOptionsForSilentLogin(IAuthenticationSchemeProvider authenticationSchemeProvider, ILogger<PostConfigureOidcOptionsForSilentLogin> logger)
+        {
+            _scheme = authenticationSchemeProvider.GetDefaultChallengeSchemeAsync().Result?.Name;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public void PostConfigure(string name, OpenIdConnectOptions options)
+        {
+            if (name == _scheme)
+            {
+                options.Events.OnRedirectToIdentityProvider = CreateRedirectCallback(options.Events.OnRedirectToIdentityProvider);
+                options.Events.OnMessageReceived = CreateMessageReceivedCallback(options.Events.OnMessageReceived);
+                options.Events.OnAuthenticationFailed = CreateAuthenticationFailedCallback(options.Events.OnAuthenticationFailed);
+            }
+        }
+
+        private Func<RedirectContext, Task> CreateRedirectCallback(Func<RedirectContext, Task> inner)
+        {
+            async Task Callback(RedirectContext ctx)
+            {
+                if (ctx.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+                {
+                    _logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login");
+                    ctx.ProtocolMessage.Prompt = "none";
+                }
+
+                if (inner != null)
+                {
+                    await inner.Invoke(ctx);
+                }
+            };
+
+            return Callback;
+        }
+
+        private Func<MessageReceivedContext, Task> CreateMessageReceivedCallback(Func<MessageReceivedContext, Task> inner)
+        {
+            async Task Callback(MessageReceivedContext ctx)
+            {
+                if (ctx.Properties!.Items.ContainsKey(Constants.BffFlags.SilentLogin) &&
+                    ctx.Properties.RedirectUri != null)
+                {
+                    ctx.HttpContext.Items[Constants.BffFlags.SilentLogin] = ctx.Properties.RedirectUri;
+
+                    if (ctx.ProtocolMessage.Error != null)
+                    {
+                        _logger.LogDebug("Handling error response from OIDC provider for BFF silent login.");
+                        ctx.HandleResponse();
+                        ctx.Response.Redirect(ctx.Properties.RedirectUri);
+                        return;
+                    }
+                }
+
+                if (inner != null)
+                {
+                    await inner.Invoke(ctx);
+                }
+            };
+
+            return Callback;
+        }
+
+        private Func<AuthenticationFailedContext, Task> CreateAuthenticationFailedCallback(Func<AuthenticationFailedContext, Task> inner)
+        {
+            async Task Callback(AuthenticationFailedContext ctx)
+            {
+                if (ctx.HttpContext.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+                {
+                    _logger.LogDebug("Handling failed response from OIDC provider for BFF silent login.");
+                    ctx.HandleResponse();
+                    ctx.Response.Redirect(ctx.HttpContext.Items[Constants.BffFlags.SilentLogin]!.ToString()!);
+                    return;
+                }
+
+                if (inner != null)
+                {
+                    await inner.Invoke(ctx);
+                }
+            };
+
+            return Callback;
+        }
+    }
+}


### PR DESCRIPTION
First stab of adding a silent login endpoint to trigger OIDC prompt=none, and handling the result. The design assumes the use of an iframe for this request/response, much like older SPA apps used to use, so this triggering code in JS must handle the results with the window.message event.

Fixes: https://github.com/DuendeSoftware/BFF/issues/45