### PR TITLE
Include PathBase on silent redirect uri

### DIFF
--- a/src/Duende.Bff/Endpoints/DefaultSilentLoginService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultSilentLoginService.cs
@@ -28,9 +28,12 @@ namespace Duende.Bff
         {
             context.CheckForBffMiddleware(_options);
 
+            var pathBase = context.Request.PathBase;
+            var redirectPath = pathBase + _options.SilentLoginCallbackPath;
+
             var props = new AuthenticationProperties
             {
-                RedirectUri = _options.SilentLoginCallbackPath,
+                RedirectUri = redirectPath,
                 Items =
                 {
                     { Constants.BffFlags.SilentLogin, "true" }


### PR DESCRIPTION
On the new silent login feature, we neglected to include PathBase when redirecting back.