### PR TITLE
Add support for custom DbContext for Sessions

### DIFF
--- a/src/Duende.Bff.EntityFramework/BffBuilderExtensions.cs
+++ b/src/Duende.Bff.EntityFramework/BffBuilderExtensions.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using Duende.Bff.EntityFramework.Interfaces;
+using Duende.Bff.EntityFramework.Options;
 
 namespace Duende.Bff.EntityFramework
 {
@@ -25,7 +27,7 @@ namespace Duende.Bff.EntityFramework
             bffBuilder.Services.AddTransient<IUserSessionStoreCleanup, UserSessionStore>();
             return bffBuilder.AddServerSideSessions<UserSessionStore>();
         }
-
+        
         /// <summary>
         /// Adds entity framework core support for user session store.
         /// </summary>
@@ -35,8 +37,108 @@ namespace Duende.Bff.EntityFramework
         public static BffBuilder AddEntityFrameworkServerSideSessions(this BffBuilder bffBuilder, Action<DbContextOptionsBuilder> action)
         {
             bffBuilder.Services.AddDbContext<SessionDbContext>(action);
+            bffBuilder.Services.AddScoped<ISessionDbContext, SessionDbContext>();
+            bffBuilder.Services.AddTransient<IUserSessionStoreCleanup, UserSessionStore>();
+            return bffBuilder.AddEntityFrameworkServerSideSessions<SessionDbContext>();
+        }
+
+        /// <summary>
+        /// Adds entity framework core support for user session store.
+        /// </summary>
+        /// <param name="bffBuilder"></param>
+        /// <param name="storeOptionsAction">The store options action.</param>
+        /// <returns></returns>
+        public static BffBuilder AddEntityFrameworkServerSideSessions(this BffBuilder bffBuilder, Action<SessionStoreOptions> storeOptionsAction = null)
+        {
+            return bffBuilder.AddEntityFrameworkServerSideSessions<SessionDbContext>(storeOptionsAction);
+        }
+        
+        /// <summary>
+        /// Adds entity framework core support for user session store.
+        /// </summary>
+        /// <param name="bffBuilder"></param>
+        /// <param name="storeOptionsAction">The store options action.</param>
+        /// <returns></returns>
+        public static BffBuilder AddEntityFrameworkServerSideSessions<TContext>(this BffBuilder bffBuilder, Action<SessionStoreOptions> storeOptionsAction = null)
+            where TContext : DbContext, ISessionDbContext
+        {
+            bffBuilder.Services.AddSessionDbContext<TContext>(storeOptionsAction);
             bffBuilder.Services.AddTransient<IUserSessionStoreCleanup, UserSessionStore>();
             return bffBuilder.AddServerSideSessions<UserSessionStore>();
+        }
+        
+        /// <summary>
+        /// Adds Session DbContext to the DI system.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="storeOptionsAction">The store options action.</param>
+        /// <returns></returns>
+        
+        public static IServiceCollection AddSessionDbContext(this IServiceCollection services,
+            Action<SessionStoreOptions> storeOptionsAction = null)
+        {
+            return services.AddSessionDbContext<SessionDbContext>(storeOptionsAction);
+        }
+        
+        /// <summary>
+        /// Adds Session DbContext to the DI system.
+        /// </summary>
+        /// <typeparam name="TContext">The ISessionDbContext to use.</typeparam>
+        /// <param name="services"></param>
+        /// <param name="storeOptionsAction">The store options action.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionDbContext<TContext>(this IServiceCollection services, Action<SessionStoreOptions> storeOptionsAction = null)
+            where TContext : DbContext, ISessionDbContext
+        {
+            var options = new SessionStoreOptions();
+            services.AddSingleton(options);
+            storeOptionsAction?.Invoke(options);
+
+            if (options.ResolveDbContextOptions != null)
+            {
+                if (options.EnablePooling)
+                {
+                    if (options.PoolSize.HasValue)
+                    {
+                        services.AddDbContextPool<TContext>(options.ResolveDbContextOptions, options.PoolSize.Value);
+                    }
+                    else
+                    {
+                        services.AddDbContextPool<TContext>(options.ResolveDbContextOptions);
+                    }
+                }
+                else
+                {
+                    services.AddDbContext<TContext>(options.ResolveDbContextOptions);
+                }
+            }
+            else
+            {
+                if (options.EnablePooling)
+                {
+                    if (options.PoolSize.HasValue)
+                    {
+                        services.AddDbContextPool<TContext>(
+                            dbCtxBuilder => { options.ConfigureDbContext?.Invoke(dbCtxBuilder); }, options.PoolSize.Value);
+                    }
+                    else
+                    {
+                        services.AddDbContextPool<TContext>(
+                            dbCtxBuilder => { options.ConfigureDbContext?.Invoke(dbCtxBuilder); });
+                    }
+                }
+                else
+                {
+                    services.AddDbContext<TContext>(dbCtxBuilder =>
+                    {
+                        options.ConfigureDbContext?.Invoke(dbCtxBuilder);
+                    });
+                }
+            }
+
+            services.AddScoped<ISessionDbContext, TContext>();
+
+            return services;
         }
     }
 }

--- a/src/Duende.Bff.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/src/Duende.Bff.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,41 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+using Duende.Bff.EntityFramework.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Duende.Bff.EntityFramework.Extensions
+{
+    /// <summary>
+    /// Extension methods to define the database schema for the session data store.
+    /// </summary>
+
+    public static class ModelBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the persisted grant context.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="storeOptions">The store options.</param>
+        public static void ConfigureSessionContext(this ModelBuilder modelBuilder, SessionStoreOptions storeOptions)
+        {
+            if (!string.IsNullOrWhiteSpace(storeOptions.DefaultSchema)) modelBuilder.HasDefaultSchema(storeOptions.DefaultSchema);
+
+            modelBuilder.Entity<UserSessionEntity>(entity =>
+            {
+                entity.HasKey(x => x.Id);
+            
+                entity.Property(x => x.ApplicationName).HasMaxLength(200);
+                entity.Property(x => x.Key).IsRequired().HasMaxLength(200);
+                entity.Property(x => x.SubjectId).IsRequired().HasMaxLength(200);
+                entity.Property(x => x.Ticket).IsRequired();
+
+                entity.HasIndex(x => new { x.ApplicationName, x.Key }).IsUnique();
+                entity.HasIndex(x => new { x.ApplicationName, x.SubjectId, x.SessionId }).IsUnique();
+                entity.HasIndex(x => new { x.ApplicationName, x.SessionId }).IsUnique();
+                entity.HasIndex(x => x.Expires);
+            });
+        }
+    }
+}

--- a/src/Duende.Bff.EntityFramework/Interfaces/ISessionDbContext.cs
+++ b/src/Duende.Bff.EntityFramework/Interfaces/ISessionDbContext.cs
@@ -1,0 +1,32 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duende.Bff.EntityFramework.Interfaces
+{
+    /// <summary>
+    /// Abstraction for the session context.
+    /// </summary>
+    /// <seealso cref="System.IDisposable" />
+    public interface ISessionDbContext : IDisposable
+    {
+        /// <summary>
+        /// Gets or sets the users sessions.
+        /// </summary>
+        /// <value>
+        /// The users sessions.
+        /// </value>
+        
+        public DbSet<UserSessionEntity> UserSessions { get; set; }
+        
+        /// <summary>
+        /// Saves the changes.
+        /// </summary>
+        /// <returns></returns>
+        Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Duende.Bff.EntityFramework/Options/SessionStoreOptions.cs
+++ b/src/Duende.Bff.EntityFramework/Options/SessionStoreOptions.cs
@@ -1,0 +1,90 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duende.Bff.EntityFramework.Options
+{
+    /// <summary>
+    /// Options for configuring the session context.
+    /// </summary>
+    public class SessionStoreOptions
+    {
+        /// <summary>
+        /// Callback to configure the EF DbContext.
+        /// </summary>
+        /// <value>
+        /// The configure database context.
+        /// </value>
+        public Action<DbContextOptionsBuilder> ConfigureDbContext { get; set; }
+        
+        /// <summary>
+        /// Callback in DI resolve the EF DbContextOptions. If set, ConfigureDbContext will not be used.
+        /// </summary>
+        /// <value>
+        /// The configure database context.
+        /// </value>
+        public Action<IServiceProvider, DbContextOptionsBuilder> ResolveDbContextOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default schema.
+        /// </summary>
+        /// <value>
+        /// The default schema.
+        /// </value>
+        public string DefaultSchema { get; set; } = null;
+        
+        /// <summary>
+        /// Gets or sets the persisted grants table configuration.
+        /// </summary>
+        /// <value>
+        /// The persisted grants.
+        /// </value>
+        public TableConfiguration UserSessions { get; set; } = new TableConfiguration("UserSessions");
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether stale entries will be automatically cleaned up from the database.
+        /// This is implemented by periodically connecting to the database (according to the TokenCleanupInterval) from the hosting application.
+        /// Defaults to false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable token cleanup]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableTokenCleanup { get; set; } = false;
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether consumed tokens will included in the automatic clean up.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if consumed tokens are to be included in cleanup; otherwise, <c>false</c>.
+        /// </value>
+        public bool RemoveConsumedTokens { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the token cleanup interval (in seconds). The default is 3600 (1 hour).
+        /// </summary>
+        /// <value>
+        /// The token cleanup interval.
+        /// </value>
+        public int TokenCleanupInterval { get; set; } = 3600;
+
+        /// <summary>
+        /// Gets or sets the number of records to remove at a time. Defaults to 100.
+        /// </summary>
+        /// <value>
+        /// The size of the token cleanup batch.
+        /// </value>
+        public int TokenCleanupBatchSize { get; set; } = 100;
+
+        /// <summary>
+        /// Gets or set if EF DbContext pooling is enabled.
+        /// </summary>
+        public bool EnablePooling { get; set; } = false;
+
+        /// <summary>
+        /// Gets or set the pool size to use when DbContext pooling is enabled. If not set, the EF default is used.
+        /// </summary>
+        public int? PoolSize { get; set; }
+    }
+}

--- a/src/Duende.Bff.EntityFramework/Options/TableConfiguration.cs
+++ b/src/Duende.Bff.EntityFramework/Options/TableConfiguration.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.Bff.EntityFramework.Options
+{
+    /// <summary>
+    /// Class to control a table's name and schema.
+    /// </summary>
+    public class TableConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableConfiguration"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        public TableConfiguration(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableConfiguration"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="schema">The schema.</param>
+        public TableConfiguration(string name, string schema)
+        {
+            Name = name;
+            Schema = schema;
+        }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schema.
+        /// </summary>
+        /// <value>
+        /// The schema.
+        /// </value>
+        public string Schema { get; set; }
+    }
+}

--- a/src/Duende.Bff.EntityFramework/UserSessionStore.cs
+++ b/src/Duende.Bff.EntityFramework/UserSessionStore.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Duende.Bff.EntityFramework.Interfaces;
 
 namespace Duende.Bff.EntityFramework
 {
@@ -21,7 +22,7 @@ namespace Duende.Bff.EntityFramework
     public class UserSessionStore : IUserSessionStore, IUserSessionStoreCleanup
     {
         private readonly string _applicationDiscriminator;
-        private readonly SessionDbContext _sessionDbContext;
+        private readonly ISessionDbContext _sessionDbContext;
         private readonly ILogger<UserSessionStore> _logger;
 
         /// <summary>
@@ -30,7 +31,7 @@ namespace Duende.Bff.EntityFramework
         /// <param name="options"></param>
         /// <param name="sessionDbContext"></param>
         /// <param name="logger"></param>
-        public UserSessionStore(IOptions<DataProtectionOptions> options, SessionDbContext sessionDbContext, ILogger<UserSessionStore> logger)
+        public UserSessionStore(IOptions<DataProtectionOptions> options, ISessionDbContext sessionDbContext, ILogger<UserSessionStore> logger)
         {
             _applicationDiscriminator = options.Value.ApplicationDiscriminator;
             _sessionDbContext = sessionDbContext;
@@ -106,7 +107,7 @@ namespace Duende.Bff.EntityFramework
                 items = items.Where(x => x.SessionId == filter.SessionId).ToArray();
             }
 
-            _sessionDbContext.RemoveRange(items);
+            _sessionDbContext.UserSessions.RemoveRange(items);
 
             try
             {

--- a/test/Duende.Bff.EntityFramework.Tests/UserSessionStoreTests.cs
+++ b/test/Duende.Bff.EntityFramework.Tests/UserSessionStoreTests.cs
@@ -21,7 +21,7 @@ namespace Duende.Bff.EntityFramework.Tests
         {
             var services = new ServiceCollection();
             services.AddBff()
-                .AddEntityFrameworkServerSideSessions(options=> options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+                .AddEntityFrameworkServerSideSessions(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
             var provider = services.BuildServiceProvider();
             
             _subject = provider.GetRequiredService<IUserSessionStore>();


### PR DESCRIPTION
**What issue does this PR address?**
This PR gives people the option to use a custom DbContext as the SessionDbContext.
The changes should be backwards compatible, but if you see something that could cause issues. I am open to fixing those issues.
A little heads up some of the code comes from: [IdentityServer](https://github.com/DuendeSoftware/IdentityServer/tree/main/src/EntityFramework.Storage)


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
