### PR TITLE
Fix for login/logout redirects when not in hosted in root

### DIFF
--- a/src/Duende.Bff/Endpoints/DefaultLoginService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultLoginService.cs
@@ -43,9 +43,21 @@ public class DefaultLoginService : ILoginService
             }
         }
 
+        if (String.IsNullOrWhiteSpace(returnUrl))
+        {
+            if (context.Request.PathBase.HasValue)
+            {
+                returnUrl = context.Request.PathBase;
+            }
+            else
+            {
+                returnUrl = "/";
+            }
+        }
+
         var props = new AuthenticationProperties
         {
-            RedirectUri = returnUrl ?? "/"
+            RedirectUri = returnUrl
         };
 
         await context.ChallengeAsync(props);

--- a/src/Duende.Bff/Endpoints/DefaultLogoutService.cs
+++ b/src/Duende.Bff/Endpoints/DefaultLogoutService.cs
@@ -72,9 +72,21 @@ public class DefaultLogoutService : ILogoutService
             }
         }
 
+        if (String.IsNullOrWhiteSpace(returnUrl))
+        {
+            if (context.Request.PathBase.HasValue)
+            {
+                returnUrl = context.Request.PathBase;
+            }
+            else
+            {
+                returnUrl = "/";
+            }
+        }
+        
         var props = new AuthenticationProperties
         {
-            RedirectUri = returnUrl ?? "/"
+            RedirectUri = returnUrl
         };
 
         // trigger idp logout


### PR DESCRIPTION
When redirecting for login/logout and no `returnUrl` param is provided, we use "/" as the `RedirectUri` for the `AuthenticationProperties`. For apps not hosted in the root, this was not treated as app relative and thus would redirect to the root of the site. This PR adds logic to use the `Request.PathBase` preserving the relative app path on those redirects.