### PR TITLE
add AllowAnonymous() on the BFF management endpoints

### DIFF
--- a/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Endpoints/BffEndpointRouteBuilderExtensions.cs
@@ -50,7 +50,8 @@ public static class BffEndpointRouteBuilderExtensions
             
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
-        endpoints.MapGet(options.LoginPath.Value!, ProcessWith<ILoginService>);
+        endpoints.MapGet(options.LoginPath.Value!, ProcessWith<ILoginService>)
+            .AllowAnonymous();
     }
 
     /// <summary>
@@ -63,8 +64,10 @@ public static class BffEndpointRouteBuilderExtensions
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
-        endpoints.MapGet(options.SilentLoginPath.Value!, ProcessWith<ISilentLoginService>);
-        endpoints.MapGet(options.SilentLoginCallbackPath.Value!, ProcessWith<ISilentLoginCallbackService>);
+        endpoints.MapGet(options.SilentLoginPath.Value!, ProcessWith<ISilentLoginService>)
+            .AllowAnonymous();
+        endpoints.MapGet(options.SilentLoginCallbackPath.Value!, ProcessWith<ISilentLoginCallbackService>)
+            .AllowAnonymous();
     }
 
     /// <summary>
@@ -77,7 +80,8 @@ public static class BffEndpointRouteBuilderExtensions
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
-        endpoints.MapGet(options.LogoutPath.Value!, ProcessWith<ILogoutService>);
+        endpoints.MapGet(options.LogoutPath.Value!, ProcessWith<ILogoutService>)
+            .AllowAnonymous();
     }
 
     /// <summary>
@@ -91,6 +95,7 @@ public static class BffEndpointRouteBuilderExtensions
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
         endpoints.MapGet(options.UserPath.Value!, ProcessWith<IUserService>)
+            .AllowAnonymous()
             .AsBffApiEndpoint();
     }
 
@@ -104,7 +109,8 @@ public static class BffEndpointRouteBuilderExtensions
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
-        endpoints.MapPost(options.BackChannelLogoutPath.Value!, ProcessWith<IBackchannelLogoutService>);
+        endpoints.MapPost(options.BackChannelLogoutPath.Value!, ProcessWith<IBackchannelLogoutService>)
+            .AllowAnonymous();
     }
         
     /// <summary>
@@ -117,7 +123,8 @@ public static class BffEndpointRouteBuilderExtensions
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
-        endpoints.MapGet(options.DiagnosticsPath.Value!, ProcessWith<IDiagnosticsService>);
+        endpoints.MapGet(options.DiagnosticsPath.Value!, ProcessWith<IDiagnosticsService>)
+            .AllowAnonymous();
     }
         
     internal static void CheckLicense(this IEndpointRouteBuilder endpoints)

--- a/test/Duende.Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
@@ -3,7 +3,9 @@
 
 using Duende.Bff.Tests.TestHosts;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,6 +13,25 @@ namespace Duende.Bff.Tests.Endpoints.Management
 {
     public class BackchannelLogoutEndpointTests : BffIntegrationTestBase
     {
+        [Fact]
+        public async Task backchannel_logout_should_allow_anonymous()
+        {
+            BffHost.OnConfigureServices += svcs =>
+            {
+                svcs.AddAuthorization(opts =>
+                {
+                    opts.FallbackPolicy =
+                        new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+            };
+            await BffHost.InitializeAsync();
+
+            var response = await BffHost.HttpClient.PostAsync(BffHost.Url("/bff/backchannel"), null);
+            response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        }
+
         [Fact]
         public async Task backchannel_logout_endpoint_should_signout()
         {

--- a/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -14,6 +14,25 @@ namespace Duende.Bff.Tests.Endpoints.Management
     public class LoginEndpointTests : BffIntegrationTestBase
     {
         [Fact]
+        public async Task login_should_allow_anonymous()
+        {
+            BffHost.OnConfigureServices += svcs =>
+            {
+                svcs.AddAuthorization(opts =>
+                {
+                    opts.FallbackPolicy =
+                        new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+            };
+            await BffHost.InitializeAsync();
+
+            var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
+            response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        }
+        
+        [Fact]
         public async Task login_endpoint_should_challenge_and_redirect_to_root()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));

--- a/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
@@ -5,6 +5,7 @@ using Duende.Bff.Tests.TestHosts;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,6 +13,25 @@ namespace Duende.Bff.Tests.Endpoints.Management
 {
     public class LogoutEndpointTests : BffIntegrationTestBase
     {
+        [Fact]
+        public async Task logout_endpoint_should_allow_anonymous()
+        {
+            BffHost.OnConfigureServices += svcs =>
+            {
+                svcs.AddAuthorization(opts =>
+                {
+                    opts.FallbackPolicy =
+                        new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+            };
+            await BffHost.InitializeAsync();
+
+            var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
+            response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        }
+
         [Fact]
         public async Task logout_endpoint_should_signout()
         {


### PR DESCRIPTION
This allows the host to configure a FallbackPolicy authorization policy, and still allow the BFF management endpoints to be used properly.