### PR TITLE
Don't throw for absent endpoint in BffAuthorizationMiddlewareResultHandler

### DIFF
--- a/src/Duende.Bff/Endpoints/BffAuthorizationMiddlewareResultHandler.cs
+++ b/src/Duende.Bff/Endpoints/BffAuthorizationMiddlewareResultHandler.cs
@@ -31,21 +31,22 @@ namespace Duende.Bff
         {
             var endpoint = context.GetEndpoint();
 
-            if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
-
-            var isBffEndpoint = endpoint.Metadata.GetMetadata<IBffApiEndpoint>() != null;
-            if (isBffEndpoint)
+            if (endpoint != null)
             {
-                if (authorizeResult.Challenged)
+                var isBffEndpoint = endpoint.Metadata.GetMetadata<IBffApiEndpoint>() != null;
+                if (isBffEndpoint)
                 {
-                    context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-                    return Task.CompletedTask;
-                }
+                    if (authorizeResult.Challenged)
+                    {
+                        context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                        return Task.CompletedTask;
+                    }
 
-                if (authorizeResult.Forbidden)
-                {
-                    context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
-                    return Task.CompletedTask;
+                    if (authorizeResult.Forbidden)
+                    {
+                        context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                        return Task.CompletedTask;
+                    }
                 }
             }
 

--- a/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
@@ -4,6 +4,7 @@
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -172,6 +173,25 @@ namespace Duende.Bff.Tests.Endpoints
             var response = await BffHost.BrowserClient.SendAsync(req);
 
             response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+
+        [Fact]
+        public async Task fallback_policy_should_not_fail()
+        {
+            BffHost.OnConfigureServices += svcs =>
+            {
+                svcs.AddAuthorization(opts =>
+                { 
+                    opts.FallbackPolicy = 
+                        new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+            };
+            await BffHost.InitializeAsync();
+
+            var response = await BffHost.HttpClient.GetAsync(BffHost.Url("/not-found"));
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
@@ -191,7 +191,7 @@ namespace Duende.Bff.Tests.Endpoints
             await BffHost.InitializeAsync();
 
             var response = await BffHost.HttpClient.GetAsync(BffHost.Url("/not-found"));
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            response.StatusCode.Should().NotBe(HttpStatusCode.InternalServerError);
         }
     }
 }


### PR DESCRIPTION
Normally the BffAuthorizationMiddlewareResultHandler is only invoked if there is an authorization policy, and that's typically due to an endpoint having some authorization metadata. Currently the BffAuthorizationMiddlewareResultHandler throws a NRE if there is no endpoint. But, it's possible that there is no endpoint, yet there is an policy due to a FallbackPolicy authorization policy. This means any requests to invalid URLs will return 500 due to the NRE we throw.

This PR removes the NRE exception and simply nops if there is no endpoint.

Fixes: https://github.com/DuendeSoftware/Support/issues/143