### PR TITLE
Improve extensibility of DefaultHttpMessageInvokerFactory

### DIFF
--- a/src/Duende.Bff.Yarp/DefaultHttpMessageInvokerFactory.cs
+++ b/src/Duende.Bff.Yarp/DefaultHttpMessageInvokerFactory.cs
@@ -9,12 +9,12 @@ namespace Duende.Bff.Yarp;
 
 /// <summary>
 /// Default implementation of the message invoker factory.
-/// This implementation creates one message invoke per remote API endpoint
+/// This implementation creates one message invoker per remote API endpoint.
 /// </summary>
 public class DefaultHttpMessageInvokerFactory : IHttpMessageInvokerFactory
 {
     /// <summary>
-    /// Dictionary to cachen invoker instances
+    /// Dictionary to cache invoker instances
     /// </summary>
     protected readonly ConcurrentDictionary<string, HttpMessageInvoker> Clients = new();
 
@@ -23,15 +23,19 @@ public class DefaultHttpMessageInvokerFactory : IHttpMessageInvokerFactory
     {
         return Clients.GetOrAdd(localPath, (key) =>
         {
-            var socketsHandler = new SocketsHttpHandler
-            {
-                UseProxy = false,
-                AllowAutoRedirect = false,
-                AutomaticDecompression = DecompressionMethods.None,
-                UseCookies = false
-            };
-            
-            return new HttpMessageInvoker(socketsHandler);
+            var handler = CreateHandler(key);
+            return new HttpMessageInvoker(handler);
         });
+    }
+    
+    protected virtual HttpMessageHandler CreateHandler(string localPath)
+    {
+        return new SocketsHttpHandler
+        {
+            UseProxy = false,
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.None,
+            UseCookies = false
+        };
     }
 }


### PR DESCRIPTION
Creating of the `HttpMessageHandler` is extracted to a virtual protected method.

**What issue does this PR address?**

Closes #136

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
