### PR TITLE
allow for other/many environments for diagnostics

### DIFF
--- a/src/Duende.Bff/Configuration/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Duende.Bff/Configuration/BffEndpointRouteBuilderExtensions.cs
@@ -114,7 +114,7 @@ public static class BffEndpointRouteBuilderExtensions
     }
         
     /// <summary>
-    /// Adds the logout BFF management endpoint
+    /// Adds the diagnostics BFF management endpoint
     /// </summary>
     /// <param name="endpoints"></param>
     public static void MapBffDiagnosticsEndpoint(this IEndpointRouteBuilder endpoints)

--- a/src/Duende.Bff/Configuration/BffOptions.cs
+++ b/src/Duende.Bff/Configuration/BffOptions.cs
@@ -2,7 +2,10 @@
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Duende.Bff;
 
@@ -117,6 +120,15 @@ public class BffOptions
     /// Defaults to Response401.
     /// </summary>
     public AnonymousSessionResponse AnonymousSessionResponse { get; set; } = AnonymousSessionResponse.Response401;
+
+    /// <summary>
+    /// The ASP.NET environment names to enable the diagnostics endpoint.
+    /// Defaults to "Development".
+    /// </summary>
+    public ICollection<string> DiagnosticsEnvironments { get; set; } = new HashSet<string>()
+    {
+        Environments.Development
+    };
 }
 
 /// <summary>

--- a/src/Duende.Bff/EndpointServices/Diagnostics/DefaultDiagnosticsService.cs
+++ b/src/Duende.Bff/EndpointServices/Diagnostics/DefaultDiagnosticsService.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Duende.Bff;
 
@@ -22,18 +23,25 @@ public class DefaultDiagnosticsService : IDiagnosticsService
     protected readonly IWebHostEnvironment Environment;
 
     /// <summary>
+    /// The BFF options
+    /// </summary>
+    protected readonly IOptions<BffOptions> Options;
+
+    /// <summary>
     /// ctor
     /// </summary>
     /// <param name="environment"></param>
-    public DefaultDiagnosticsService(IWebHostEnvironment environment)
+    /// <param name="options"></param>
+    public DefaultDiagnosticsService(IWebHostEnvironment environment, IOptions<BffOptions> options)
     {
         Environment = environment;
+        Options = options;
     }
         
     /// <inheritdoc />
     public virtual async Task ProcessRequestAsync(HttpContext context)
     {
-        if (!Environment.IsDevelopment())
+        if (Options.Value.DiagnosticsEnvironments?.Contains(Environment.EnvironmentName) is null or false)
         {
             context.Response.StatusCode = 404;
             return;


### PR DESCRIPTION
This PR adds a new option called *DiagnosticsEnvironments* which is a collection of environment names that will allow the *DefaultDiagnosticsService* to issue a response.

Once merged, requires a doc update.

Fixes: https://github.com/DuendeSoftware/BFF/issues/143