### PR TITLE
revert reference to EF Core back to 6.0.0 (rather than the latest patch)

### DIFF
--- a/src/Duende.Bff.EntityFramework/Duende.Bff.EntityFramework.csproj
+++ b/src/Duende.Bff.EntityFramework/Duende.Bff.EntityFramework.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We should only be referencing the base version of any dependent packages from ASP.NET Core.

Fixes: https://github.com/DuendeSoftware/BFF/issues/145