### PR TITLE
Improve validation message of logout token

### DIFF
--- a/src/Duende.Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
+++ b/src/Duende.Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
@@ -132,7 +132,7 @@ public class DefaultBackchannelLogoutService : IBackchannelLogoutService
 
         if (claims.FindFirst("sub") == null && claims.FindFirst("sid") == null)
         {
-            Logger.BackChannelLogoutError("Logout token missing sub or sid claims.");
+            Logger.BackChannelLogoutError("Logout token missing sub and sid claims.");
             return null;
         }
 


### PR DESCRIPTION
Very minor change to the validation message to clarify that both sub *and* sid are missing.
