### PR TITLE
Update Blazor6 Sample with Cookie SameSite Guidance

### DIFF
--- a/samples/Blazor6/Server/Program.cs
+++ b/samples/Blazor6/Server/Program.cs
@@ -38,6 +38,9 @@ try
         .AddCookie("cookie", options =>
         {
             options.Cookie.Name = "__Host-blazor";
+
+            // If your authority is on a different domain from your SPA (blazor in this case), you might want to use Lax instead of Strict
+            // See https://github.com/DuendeSoftware/Support/issues/565
             options.Cookie.SameSite = SameSiteMode.Strict;
         })
         .AddOpenIdConnect("oidc", options =>


### PR DESCRIPTION
**What issue does this PR address?**
Just a comment to help guide usage for scenarios where the instance of Identity Server is running in a different domain.

Relates to: https://github.com/DuendeSoftware/Support/issues/565