### PR TITLE
Joe/remote api token retreival

### DIFF
--- a/samples/Api/EchoController.cs
+++ b/samples/Api/EchoController.cs
@@ -14,7 +14,7 @@ namespace Api
         public IActionResult Get()
         {
             string message;
-            var sub = User.FindFirst(("sub"));
+            var sub = User.FindFirst("sub");
             
             if (!User.Identity.IsAuthenticated)
             {
@@ -22,7 +22,7 @@ namespace Api
             }
             else if (sub != null)
             {
-                var userName = User.FindFirst(("name"));
+                var userName = User.FindFirst("name");
                 message = $"Hello user, {userName.Value}";
             }
             else

--- a/samples/IdentityServer/Config.cs
+++ b/samples/IdentityServer/Config.cs
@@ -3,6 +3,7 @@
 
 
 using Duende.IdentityServer.Models;
+using IdentityModel;
 
 namespace IdentityServerHost
 {
@@ -29,7 +30,12 @@ namespace IdentityServerHost
                     ClientId = "spa",
                     ClientSecrets = { new Secret("secret".Sha256()) },
                     
-                    AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
+                    AllowedGrantTypes = 
+                    { 
+                        GrantType.AuthorizationCode, 
+                        GrantType.ClientCredentials,
+                        OidcConstants.GrantTypes.TokenExchange 
+                    },
 
                     RedirectUris = { "https://localhost:5002/signin-oidc" },
                     

--- a/samples/IdentityServer/Extensions.cs
+++ b/samples/IdentityServer/Extensions.cs
@@ -25,6 +25,7 @@ internal static class Extensions
         isBuilder.AddInMemoryIdentityResources(Config.IdentityResources);
         isBuilder.AddInMemoryApiScopes(Config.ApiScopes);
         isBuilder.AddInMemoryClients(Config.Clients);
+        isBuilder.AddExtensionGrantValidator<TokenExchangeGrantValidator>();
 
         return builder.Build();
     }

--- a/samples/IdentityServer/TokenExchangeGrantValidator.cs
+++ b/samples/IdentityServer/TokenExchangeGrantValidator.cs
@@ -1,0 +1,70 @@
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Validation;
+using IdentityModel;
+
+namespace IdentityServerHost;
+
+public class TokenExchangeGrantValidator : IExtensionGrantValidator
+{
+    private readonly ITokenValidator _validator;
+
+    public TokenExchangeGrantValidator(ITokenValidator validator)
+    {
+        _validator = validator;
+    }
+
+    // register for urn:ietf:params:oauth:grant-type:token-exchange
+    public string GrantType => OidcConstants.GrantTypes.TokenExchange;
+    
+    public async Task ValidateAsync(ExtensionGrantValidationContext context)
+    {
+        // default response is error
+        context.Result = new GrantValidationResult(TokenRequestErrors.InvalidRequest);
+        
+        // the spec allows for various token types, most commonly you return an access token
+        var customResponse = new Dictionary<string, object>
+        {
+            { OidcConstants.TokenResponse.IssuedTokenType, OidcConstants.TokenTypeIdentifiers.AccessToken }
+        };
+        
+        // read the incoming token
+        var subjectToken = context.Request.Raw.Get(OidcConstants.TokenRequest.SubjectToken);
+        
+        // and the token type
+        var subjectTokenType = context.Request.Raw.Get(OidcConstants.TokenRequest.SubjectTokenType);
+        
+        // mandatory parameters
+        if (string.IsNullOrWhiteSpace(subjectToken))
+        {
+            return;
+        }
+        
+        // for our impersonation/delegation scenario we require an access token
+        if (!string.Equals(subjectTokenType, OidcConstants.TokenTypeIdentifiers.AccessToken))
+        {
+            return;
+        }
+
+        // validate the incoming access token with the built-in token validator
+        var validationResult = await _validator.ValidateAccessTokenAsync(subjectToken);
+        if (validationResult.IsError)
+        {
+            return;
+        }
+
+        // these are two values you typically care about
+        var sub = validationResult.Claims.First(c => c.Type == JwtClaimTypes.Subject).Value;
+
+        var alice = TestUsers.Users.Single(u => u.Username == "alice").SubjectId;
+        var bob = TestUsers.Users.Single(u => u.Username == "bob").SubjectId;
+
+        var impersonateSub = sub == alice ? bob : alice;
+        var impersonateClaims = TestUsers.Users.Single(u => u.SubjectId == impersonateSub).Claims;
+
+        // create response
+        context.Result = new GrantValidationResult(
+            subject: impersonateSub, 
+            authenticationMethod: "swap-alice-and-bob",
+            claims: impersonateClaims);
+    }
+}

--- a/samples/JS6/ImpersonationAccessTokenRetriever.cs
+++ b/samples/JS6/ImpersonationAccessTokenRetriever.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Duende.Bff;
+using IdentityModel;
+using IdentityModel.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Host6;
+
+public class ImpersonationAccessTokenRetriever : DefaultAccessTokenRetriever
+{
+    public ImpersonationAccessTokenRetriever(ILogger<ImpersonationAccessTokenRetriever> logger) : base(logger)
+    {
+    }
+    
+    public override async Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context)
+    {
+        var result = await base.GetAccessToken(context);
+
+        if(result.Token != null)
+        {
+            var client = new HttpClient();
+            var exchangeResponse = await client.RequestTokenExchangeTokenAsync(new TokenExchangeTokenRequest
+            {
+                Address = "https://localhost:5001/connect/token",
+                GrantType = OidcConstants.GrantTypes.TokenExchange,
+
+                ClientId = "spa",
+                ClientSecret = "secret",
+
+                SubjectToken = result.Token,
+                SubjectTokenType = OidcConstants.TokenTypeIdentifiers.AccessToken
+            });
+            if(exchangeResponse.IsError)
+            {
+                return new AccessTokenResult
+                {
+                    IsError = true
+                };
+            } 
+            return new AccessTokenResult
+            {
+                IsError = false,
+                Token = exchangeResponse.AccessToken
+            };
+        }
+
+        return result;
+    }
+}

--- a/samples/JS6/LocalApiController.cs
+++ b/samples/JS6/LocalApiController.cs
@@ -3,20 +3,18 @@
 
 using Microsoft.AspNetCore.Mvc;
 
-namespace Host5
+namespace Host6;
+[Route("local")]
+public class LocalApiController : ControllerBase
 {
-    [Route("local")]
-    public class LocalApiController : ControllerBase
+    public IActionResult Get()
     {
-        public IActionResult Get()
+        var data = new
         {
-            var data = new
-            {
-                Message = "Hello from local API",
-                User = User!.FindFirst("name")?.Value ?? User!.FindFirst("sub")!.Value
-            };
+            Message = "Hello from local API",
+            User = User!.FindFirst("name")?.Value ?? User!.FindFirst("sub")!.Value
+        };
 
-            return Ok(data);
-        }
+        return Ok(data);
     }
 }

--- a/samples/JS6/Program.cs
+++ b/samples/JS6/Program.cs
@@ -8,48 +8,47 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
 
-namespace Host5
+namespace Host6;
+
+public class Program
 {
-    public class Program
+    public static int Main(string[] args)
     {
-        public static int Main(string[] args)
-        {
-            Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Information()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-                .MinimumLevel.Override("IdentityModel", LogEventLevel.Debug)
-                .MinimumLevel.Override("Duende.Bff", LogEventLevel.Debug)
-                .Enrich.FromLogContext()
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Code)
-                .CreateLogger();
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+            .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
+            .MinimumLevel.Override("IdentityModel", LogEventLevel.Debug)
+            .MinimumLevel.Override("Duende.Bff", LogEventLevel.Debug)
+            .Enrich.FromLogContext()
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Code)
+            .CreateLogger();
 
-            try
-            {
-                Log.Information("Starting host...");
-                CreateHostBuilder(args).Build().Run();
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "Host terminated unexpectedly.");
-                return 1;
-            }
-            finally
-            {
-                Log.CloseAndFlush();
-            }
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args)
+        try
         {
-            return Host.CreateDefaultBuilder(args)
-                .UseSerilog()
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
+            Log.Information("Starting host...");
+            CreateHostBuilder(args).Build().Run();
+            return 0;
         }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "Host terminated unexpectedly.");
+            return 1;
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+        }
+    }
+
+    public static IHostBuilder CreateHostBuilder(string[] args)
+    {
+        return Host.CreateDefaultBuilder(args)
+            .UseSerilog()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
     }
 }

--- a/samples/JS6/Startup.cs
+++ b/samples/JS6/Startup.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Duende.Bff;
 using Duende.Bff.Yarp;
 using Microsoft.AspNetCore.Builder;
@@ -9,101 +10,108 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
-namespace Host5
+namespace Host6;
+
+public class Startup
 {
-    public class Startup
+    public void ConfigureServices(IServiceCollection services)
     {
-        public void ConfigureServices(IServiceCollection services)
-        {
-            // Add BFF services to DI - also add server-side session management
-            services.AddBff(options => 
-                {
-                    //options.UserEndpointReturnNullForAnonymousUser = true;
-                })
-                .AddRemoteApis()
-                .AddServerSideSessions();
-            
-            // local APIs
-            services.AddControllers();
-
-            // cookie options
-            services.AddAuthentication(options =>
-                {
-                    options.DefaultScheme = "cookie";
-                    options.DefaultChallengeScheme = "oidc";
-                    options.DefaultSignOutScheme = "oidc";
-                })
-                .AddCookie("cookie", options =>
-                {
-                    // set session lifetime
-                    options.ExpireTimeSpan = TimeSpan.FromHours(8);
-                    
-                    // sliding or absolute
-                    options.SlidingExpiration = false;
-                    
-                    // host prefixed cookie name
-                    options.Cookie.Name = "__Host-spa5";
-                    
-                    // strict SameSite handling
-                    options.Cookie.SameSite = SameSiteMode.Strict;
-                })
-                .AddOpenIdConnect("oidc", options =>
-                {
-                    options.Authority = "https://localhost:5001";
-                    
-                    // confidential client using code flow + PKCE
-                    options.ClientId = "spa";
-                    options.ClientSecret = "secret";
-                    options.ResponseType = "code";
-                    options.ResponseMode = "query";
-
-                    options.MapInboundClaims = false;
-                    options.GetClaimsFromUserInfoEndpoint = true;
-                    options.SaveTokens = true;
-
-                    // request scopes + refresh tokens
-                    options.Scope.Clear();
-                    options.Scope.Add("openid");
-                    options.Scope.Add("profile");
-                    options.Scope.Add("api");
-                    options.Scope.Add("offline_access");
-                });
-        }
-
-        public void Configure(IApplicationBuilder app)
-        {
-            app.UseSerilogRequestLogging();
-            app.UseDeveloperExceptionPage();
-
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
-
-            app.UseAuthentication();
-            app.UseRouting();
-            
-            // adds antiforgery protection for local APIs
-            app.UseBff();
-            
-            // adds authorization for local and remote API endpoints
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
+        // Add BFF services to DI - also add server-side session management
+        services.AddBff(options =>
             {
-                // local APIs
-                endpoints.MapControllers()
-                    .RequireAuthorization()
-                    .AsBffApiEndpoint();
+                //options.UserEndpointReturnNullForAnonymousUser = true;
+            })
+            .AddRemoteApis()
+            .AddServerSideSessions();
 
-                // login, logout, user, backchannel logout...
-                endpoints.MapBffManagementEndpoints();
-                
-                // proxy endpoint for cross-site APIs
-                // all calls to /api/* will be forwarded to the remote API
-                // user or client access token will be attached in API call
-                // user access token will be managed automatically using the refresh token
-                endpoints.MapRemoteBffApiEndpoint("/api", "https://localhost:5010")
-                    .RequireAccessToken(TokenType.UserOrClient);
+        // local APIs
+        services.AddControllers();
+
+        // cookie options
+        services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = "cookie";
+                options.DefaultChallengeScheme = "oidc";
+                options.DefaultSignOutScheme = "oidc";
+            })
+            .AddCookie("cookie", options =>
+            {
+                // set session lifetime
+                options.ExpireTimeSpan = TimeSpan.FromHours(8);
+
+                // sliding or absolute
+                options.SlidingExpiration = false;
+
+                // host prefixed cookie name
+                options.Cookie.Name = "__Host-spa5";
+
+                // strict SameSite handling
+                options.Cookie.SameSite = SameSiteMode.Strict;
+            })
+            .AddOpenIdConnect("oidc", options =>
+            {
+                options.Authority = "https://localhost:5001";
+
+                // confidential client using code flow + PKCE
+                options.ClientId = "spa";
+                options.ClientSecret = "secret";
+                options.ResponseType = "code";
+                options.ResponseMode = "query";
+
+                options.MapInboundClaims = false;
+                options.GetClaimsFromUserInfoEndpoint = true;
+                options.SaveTokens = true;
+
+                // request scopes + refresh tokens
+                options.Scope.Clear();
+                options.Scope.Add("openid");
+                options.Scope.Add("profile");
+                options.Scope.Add("api");
+                options.Scope.Add("offline_access");
             });
-        }
+        services.AddSingleton<ImpersonationAccessTokenRetriever>();
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseSerilogRequestLogging();
+        app.UseDeveloperExceptionPage();
+
+        app.UseDefaultFiles();
+        app.UseStaticFiles();
+
+        app.UseAuthentication();
+        app.UseRouting();
+
+        // adds antiforgery protection for local APIs
+        app.UseBff();
+
+        // adds authorization for local and remote API endpoints
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
+        {
+            // local APIs
+            endpoints.MapControllers()
+                .RequireAuthorization()
+                .AsBffApiEndpoint();
+
+            // login, logout, user, backchannel logout...
+            endpoints.MapBffManagementEndpoints();
+
+            // On this path, we perform token exchange to impersonate a different user
+            // before making the api request
+            endpoints.MapRemoteBffApiEndpoint("/api/impersonation", "https://localhost:5010")
+                .RequireAccessToken(TokenType.UserOrClient)
+                .WithAccessTokenRetriever<ImpersonationAccessTokenRetriever>();
+
+            // proxy endpoint for cross-site APIs
+            // all calls to /api/* will be forwarded to the remote API
+            // user or client access token will be attached in API call
+            // user access token will be managed automatically using the refresh token
+            endpoints.MapRemoteBffApiEndpoint("/api", "https://localhost:5010")
+                .RequireAccessToken(TokenType.UserOrClient);
+
+        });
     }
 }

--- a/samples/JS6/wwwroot/app.js
+++ b/samples/JS6/wwwroot/app.js
@@ -91,9 +91,23 @@ async function callCrossApi() {
     }
 }
 
+async function callImpersonationApi() {
+    var req = new Request(remoteApiUrl + "/impersonation", {
+        headers: new Headers({
+            'X-CSRF': '1'
+        })
+    })
+    var resp = await fetch(req);
+
+    log("API Result: " + resp.status);
+    if (resp.ok) {
+        showApi(await resp.json());
+    }
+}
 
 document.querySelector(".login").addEventListener("click", login, false);
 document.querySelector(".call_cross").addEventListener("click", callCrossApi, false);
+document.querySelector(".call_impersonation").addEventListener("click", callImpersonationApi, false);
 document.querySelector(".call_local").addEventListener("click", callLocalApi, false);
 document.querySelector(".logout").addEventListener("click", logout, false);
 

--- a/samples/JS6/wwwroot/index.html
+++ b/samples/JS6/wwwroot/index.html
@@ -18,6 +18,7 @@
                 <li><button class="btn btn-default login">Login</button></li>
                 <li><button class="btn btn-primary call_local">Call Service (local)</button></li>
                 <li><button class="btn btn-primary call_cross">Call Service (cross-site)</button></li>
+                <li><button class="btn btn-primary call_impersonation">Call Service (with impersonation)</button></li>
                 <li><button class="btn btn-info logout">Logout</button></li>
             </ul>
         </div>

--- a/src/Duende.Bff.Yarp/AccessTokenTransformProvider.cs
+++ b/src/Duende.Bff.Yarp/AccessTokenTransformProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
+using Duende.Bff.Logging;
 using Duende.Bff.Yarp.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Duende.Bff.Yarp/Log.cs
+++ b/src/Duende.Bff.Yarp/Log.cs
@@ -8,26 +8,16 @@ namespace Duende.Bff.Yarp.Logging;
 
 internal static class EventIds
 {
-    public static readonly EventId AccessTokenMissing = new (4, "AccessTokenMissing");
     public static readonly EventId ProxyError = new (5, "ProxyError");
 }
     
 internal static class Log
 {
-    private static readonly Action<ILogger, string, string, Exception?> _accessTokenMissing = LoggerMessage.Define<string, string>(
-        LogLevel.Warning,
-        EventIds.AccessTokenMissing,
-        "Access token is missing. token type: '{tokenType}', local path: '{localpath}'.");
 
     private static readonly Action<ILogger, string, string, Exception?> _proxyResponseError = LoggerMessage.Define<string, string>(
         LogLevel.Information,
         EventIds.ProxyError,
         "Proxy response error. local path: '{localPath}', error: '{error}'");
-        
-    public static void AccessTokenMissing(this ILogger logger, string localPath, TokenType? tokenType)
-    {
-        _accessTokenMissing(logger, tokenType?.ToString() ?? "Unknown token type", localPath, null);
-    }
         
     public static void ProxyResponseError(this ILogger logger, string localPath, string error)
     { 

--- a/src/Duende.Bff.Yarp/Log.cs
+++ b/src/Duende.Bff.Yarp/Log.cs
@@ -24,9 +24,9 @@ internal static class Log
         EventIds.ProxyError,
         "Proxy response error. local path: '{localPath}', error: '{error}'");
         
-    public static void AccessTokenMissing(this ILogger logger, string localPath, TokenType tokenType)
+    public static void AccessTokenMissing(this ILogger logger, string localPath, TokenType? tokenType)
     {
-        _accessTokenMissing(logger, tokenType.ToString(), localPath, null);
+        _accessTokenMissing(logger, tokenType?.ToString() ?? "Unknown token type", localPath, null);
     }
         
     public static void ProxyResponseError(this ILogger logger, string localPath, string error)

--- a/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
+++ b/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
@@ -70,7 +70,6 @@ public static class RemoteApiEndpoint
 
             if (result.IsError)
             {
-                logger.AccessTokenMissing(localPath, metadata.RequiredTokenType);
                 context.Response.StatusCode = 401;
                 return;
             } 

--- a/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
+++ b/src/Duende.Bff.Yarp/RemoteApiEndpoint.cs
@@ -41,53 +41,58 @@ public static class RemoteApiEndpoint
             var metadata = endpoint.Metadata.GetMetadata<BffRemoteApiEndpointMetadata>();
             if (metadata == null)
             {
-                throw new InvalidOperationException("API endoint is missing BFF metadata");
+                throw new InvalidOperationException("API endpoint is missing BFF metadata");
             }
 
-            UserTokenRequestParameters? toUserAccessTokenParameters = null;
+            UserTokenRequestParameters? userAccessTokenParameters = null;
 
             if (metadata.BffUserAccessTokenParameters != null)
             {
-                toUserAccessTokenParameters = metadata.BffUserAccessTokenParameters.ToUserAccessTokenRequestParameters();
+                userAccessTokenParameters = metadata.BffUserAccessTokenParameters.ToUserAccessTokenRequestParameters();
             }
 
-            string? token = null;
-            if (metadata.RequiredTokenType.HasValue)
+            if (context.RequestServices.GetRequiredService(metadata.AccessTokenRetriever) 
+                is not IAccessTokenRetriever accessTokenRetriever)
             {
-                token = await context.GetManagedAccessToken(metadata.RequiredTokenType.Value, toUserAccessTokenParameters);
-                if (string.IsNullOrWhiteSpace(token))
+                throw new InvalidOperationException("TokenRetriever is not an IAccessTokenRetriever");
+            }
+
+            var accessTokenContext = new AccessTokenRetrievalContext()
+            {
+                HttpContext = context,
+                Metadata = metadata,
+                UserTokenRequestParameters = userAccessTokenParameters,
+                ApiAddress = apiAddress,
+                LocalPath = localPath,
+
+            };
+            var result = await accessTokenRetriever.GetAccessToken(accessTokenContext);
+
+            if (result.IsError)
+            {
+                logger.AccessTokenMissing(localPath, metadata.RequiredTokenType);
+                context.Response.StatusCode = 401;
+                return;
+            } 
+            else
+            {
+                var forwarder = context.RequestServices.GetRequiredService<IHttpForwarder>();
+                var clientFactory = context.RequestServices.GetRequiredService<IHttpMessageInvokerFactory>();
+                var transformerFactory = context.RequestServices.GetRequiredService<IHttpTransformerFactory>();
+
+                var httpClient = clientFactory.CreateClient(localPath);
+                var transformer = transformerFactory.CreateTransformer(localPath, result.Token);
+
+                await forwarder.SendAsync(context, apiAddress, httpClient, ForwarderRequestConfig.Empty, transformer);
+
+                var errorFeature = context.Features.Get<IForwarderErrorFeature>();
+                if (errorFeature != null)
                 {
-                    logger.AccessTokenMissing(localPath, metadata.RequiredTokenType.Value);
+                    var error = errorFeature.Error;
+                    var exception = errorFeature.Exception;
 
-                    context.Response.StatusCode = 401;
-                    return;
+                    logger.ProxyResponseError(localPath, exception?.ToString() ?? error.ToString());
                 }
-            }
-
-            if (token == null)
-            {
-                if (metadata.OptionalUserToken)
-                {
-                    token = (await context.GetUserAccessTokenAsync(toUserAccessTokenParameters)).AccessToken;
-                }
-            }
-
-            var forwarder = context.RequestServices.GetRequiredService<IHttpForwarder>();
-            var clientFactory = context.RequestServices.GetRequiredService<IHttpMessageInvokerFactory>();
-            var transformerFactory = context.RequestServices.GetRequiredService<IHttpTransformerFactory>();
-                
-            var httpClient = clientFactory.CreateClient(localPath);
-            var transformer = transformerFactory.CreateTransformer(localPath, token);
-
-            await forwarder.SendAsync(context, apiAddress, httpClient, ForwarderRequestConfig.Empty, transformer);
-
-            var errorFeature = context.Features.Get<IForwarderErrorFeature>();
-            if (errorFeature != null)
-            {
-                var error = errorFeature.Error;
-                var exception = errorFeature.Exception;
-
-                logger.ProxyResponseError(localPath, exception?.ToString() ?? error.ToString());
             }
         };
     }

--- a/src/Duende.Bff/Configuration/BffOptions.cs
+++ b/src/Duende.Bff/Configuration/BffOptions.cs
@@ -122,7 +122,7 @@ public class BffOptions
     public AnonymousSessionResponse AnonymousSessionResponse { get; set; } = AnonymousSessionResponse.Response401;
 
     /// <summary>
-    /// The ASP.NET environment names to enable the diagnostics endpoint.
+    /// The ASP.NET environment names that enable the diagnostics endpoint.
     /// Defaults to "Development".
     /// </summary>
     public ICollection<string> DiagnosticsEnvironments { get; set; } = new HashSet<string>()

--- a/src/Duende.Bff/Configuration/BffRemoteApiEndpointExtensions.cs
+++ b/src/Duende.Bff/Configuration/BffRemoteApiEndpointExtensions.cs
@@ -14,8 +14,7 @@ public static class BffRemoteApiEndpointExtensions
 {
     private static BffRemoteApiEndpointMetadata GetBffRemoteApiEndpointMetadata(this EndpointBuilder builder)
     {
-        var t = typeof(BffRemoteApiEndpointMetadata);
-        if(builder.Metadata.First(m => m.GetType() == t) 
+        if(builder.Metadata.First(m => m.GetType() == typeof(BffRemoteApiEndpointMetadata)) 
             is not BffRemoteApiEndpointMetadata metadata)
         {
             throw new InvalidOperationException("no metadata found");
@@ -40,7 +39,6 @@ public static class BffRemoteApiEndpointExtensions
         return builder;
     }
 
-
     /// <summary>
     /// Specifies a type to use for access token retrieval.
     /// </summary>
@@ -54,11 +52,6 @@ public static class BffRemoteApiEndpointExtensions
         builder.Add(endpointBuilder =>
         {
             var metadata = endpointBuilder.GetBffRemoteApiEndpointMetadata();
-            if (metadata.AccessTokenRetriever != null)
-            {
-                throw new InvalidOperationException("Only call WithTokenRetriever once per endpoint");
-            }
-
             metadata.AccessTokenRetriever = typeof(TRetriever);
         });
         return builder;

--- a/src/Duende.Bff/Configuration/BffRemoteApiEndpointExtensions.cs
+++ b/src/Duende.Bff/Configuration/BffRemoteApiEndpointExtensions.cs
@@ -12,6 +12,17 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class BffRemoteApiEndpointExtensions
 {
+    private static BffRemoteApiEndpointMetadata GetBffRemoteApiEndpointMetadata(this EndpointBuilder builder)
+    {
+        var t = typeof(BffRemoteApiEndpointMetadata);
+        if(builder.Metadata.First(m => m.GetType() == t) 
+            is not BffRemoteApiEndpointMetadata metadata)
+        {
+            throw new InvalidOperationException("no metadata found");
+        }
+        return metadata;
+    }
+
     /// <summary>
     /// Specifies the access tokens requirements for an endpoint
     /// </summary>
@@ -23,8 +34,8 @@ public static class BffRemoteApiEndpointExtensions
     {
         builder.Add(endpointBuilder =>
         {
-            var metadata =
-                endpointBuilder.Metadata.First(m => m.GetType() == typeof(BffRemoteApiEndpointMetadata)) as BffRemoteApiEndpointMetadata;
+            var metadata = endpointBuilder.GetBffRemoteApiEndpointMetadata();
+            metadata.RequiredTokenType = type;
 
             if (metadata == null) throw new InvalidOperationException("no metadata found");
                 
@@ -44,11 +55,7 @@ public static class BffRemoteApiEndpointExtensions
     {
         builder.Add(endpointBuilder =>
         {
-            var metadata =
-                endpointBuilder.Metadata.First(m => m.GetType() == typeof(BffRemoteApiEndpointMetadata)) as BffRemoteApiEndpointMetadata;
-
-            if (metadata == null) throw new InvalidOperationException("no metadata found");
-                
+            var metadata = endpointBuilder.GetBffRemoteApiEndpointMetadata();
             metadata.OptionalUserToken = true;
         });
 
@@ -66,11 +73,7 @@ public static class BffRemoteApiEndpointExtensions
     {
         builder.Add(endpointBuilder =>
         {
-            var metadata =
-                endpointBuilder.Metadata.First(m => m.GetType() == typeof(BffRemoteApiEndpointMetadata)) as BffRemoteApiEndpointMetadata;
-
-            if (metadata == null) throw new InvalidOperationException("no metadata found");
-                
+            var metadata = endpointBuilder.GetBffRemoteApiEndpointMetadata();
             metadata.BffUserAccessTokenParameters = bffUserAccessTokenParameters;
         });
 

--- a/src/Duende.Bff/Configuration/BffRemoteApiEndpointExtensions.cs
+++ b/src/Duende.Bff/Configuration/BffRemoteApiEndpointExtensions.cs
@@ -36,15 +36,34 @@ public static class BffRemoteApiEndpointExtensions
         {
             var metadata = endpointBuilder.GetBffRemoteApiEndpointMetadata();
             metadata.RequiredTokenType = type;
-
-            if (metadata == null) throw new InvalidOperationException("no metadata found");
-                
-            metadata.RequiredTokenType = type;
         });
-
         return builder;
     }
-        
+
+
+    /// <summary>
+    /// Specifies a type to use for access token retrieval.
+    /// </summary>
+    /// <typeparam name="TRetriever"></typeparam>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">When invoked multiple times for the same endpoint.</exception>
+    public static IEndpointConventionBuilder WithAccessTokenRetriever<TRetriever>(this IEndpointConventionBuilder builder) 
+        where TRetriever : IAccessTokenRetriever
+    {
+        builder.Add(endpointBuilder =>
+        {
+            var metadata = endpointBuilder.GetBffRemoteApiEndpointMetadata();
+            if (metadata.AccessTokenRetriever != null)
+            {
+                throw new InvalidOperationException("Only call WithTokenRetriever once per endpoint");
+            }
+
+            metadata.AccessTokenRetriever = typeof(TRetriever);
+        });
+        return builder;
+    }
+
     /// <summary>
     /// Allows for anonymous access with an optional user token for an endpoint
     /// </summary>

--- a/src/Duende.Bff/Configuration/BffRemoteApiEndpointMetadata.cs
+++ b/src/Duende.Bff/Configuration/BffRemoteApiEndpointMetadata.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System;
+
 namespace Duende.Bff;
 
 /// <summary>
@@ -12,7 +14,7 @@ public class BffRemoteApiEndpointMetadata : IBffApiEndpoint
     /// Required token type (if any)
     /// </summary>
     public TokenType? RequiredTokenType;
-        
+
     /// <summary>
     /// Optionally send a user token if present
     /// </summary>
@@ -22,4 +24,28 @@ public class BffRemoteApiEndpointMetadata : IBffApiEndpoint
     /// Maps to UserAccessTokenParameters and included if set
     /// </summary>
     public BffUserAccessTokenParameters? BffUserAccessTokenParameters { get; set; }
+
+    private Type _accessTokenRetriever = typeof(DefaultAccessTokenRetriever);
+
+    /// <summary>
+    /// The type used to retrieve access tokens.
+    /// </summary>
+    public Type AccessTokenRetriever
+    {
+        get
+        {
+            return _accessTokenRetriever;
+        }
+        set
+        {
+            if (value.IsAssignableTo(typeof(IAccessTokenRetriever)))
+            {
+                _accessTokenRetriever = value;
+            }
+            else
+            {
+                throw new Exception("Attempt to assign a AccessTokenRetriever type that cannot be assigned to IAccessTokenTokenRetriever");
+            }
+        }
+    }
 }

--- a/src/Duende.Bff/Configuration/BffServiceCollectionExtensions.cs
+++ b/src/Duende.Bff/Configuration/BffServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ public static class BffServiceCollectionExtensions
         services.AddOpenIdConnectAccessTokenManagement();
 
         services.AddTransient<IReturnUrlValidator, LocalUrlReturnUrlValidator>();
-        services.TryAddSingleton<IAccessTokenRetriever, DefaultAccessTokenRetriever>();
+        services.TryAddSingleton<DefaultAccessTokenRetriever>();
 
         // management endpoints
         services.AddTransient<ILoginService, DefaultLoginService>();

--- a/src/Duende.Bff/Configuration/BffServiceCollectionExtensions.cs
+++ b/src/Duende.Bff/Configuration/BffServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class BffServiceCollectionExtensions
         services.AddOpenIdConnectAccessTokenManagement();
 
         services.AddTransient<IReturnUrlValidator, LocalUrlReturnUrlValidator>();
+        services.TryAddSingleton<IAccessTokenRetriever, DefaultAccessTokenRetriever>();
 
         // management endpoints
         services.AddTransient<ILoginService, DefaultLoginService>();

--- a/src/Duende.Bff/General/AccessTokenResult.cs
+++ b/src/Duende.Bff/General/AccessTokenResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System;
+
+namespace Duende.Bff;
+
+/// <summary>
+/// Represents the result of attempting to obtain an access token.
+/// </summary>
+public class AccessTokenResult
+{
+    /// <summary>
+    /// Flag that indicates if access token retrieval failed.
+    /// </summary>
+    public bool IsError { get; set; }
+
+    /// <summary>
+    /// The access token, or null if an error occurred or an optional token was
+    /// not found.
+    /// </summary>
+    public string? Token { get; set; }
+}

--- a/src/Duende.Bff/General/AccessTokenResult.cs
+++ b/src/Duende.Bff/General/AccessTokenResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System;
-
 namespace Duende.Bff;
 
 /// <summary>

--- a/src/Duende.Bff/General/AccessTokenRetreivalContext.cs
+++ b/src/Duende.Bff/General/AccessTokenRetreivalContext.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System;
+using Duende.AccessTokenManagement.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+
+namespace Duende.Bff;
+
+/// <summary>
+/// Encapsulates contextual data used to retreive an access token.
+/// </summary>
+public class AccessTokenRetrievalContext
+{
+    /// <summary>
+    /// The HttpContext of the incoming HTTP request that will be forwarded to
+    /// the remote API.
+    /// </summary>
+    public HttpContext HttpContext { get; set; } = default!;
+    
+    /// <summary>
+    /// Metadata that describes the remote API.
+    /// </summary>
+    public BffRemoteApiEndpointMetadata Metadata { get; set; } = default!;
+    
+    /// <summary>
+    /// The locally requested path.
+    /// </summary>
+    public string LocalPath { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// The remote address of the API.
+    /// </summary>
+    public string ApiAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Additional optional per request parameters for a user access token request.
+    /// </summary>
+    public UserTokenRequestParameters? UserTokenRequestParameters { get; set; }
+}

--- a/src/Duende.Bff/General/DefaultAccessTokenRetriever.cs
+++ b/src/Duende.Bff/General/DefaultAccessTokenRetriever.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+namespace Duende.Bff;
+
+/// <summary>
+/// Default implementation of IAccessTokenRetriever
+/// </summary>
+public class DefaultAccessTokenRetriever : IAccessTokenRetriever
+{
+    /// <inheritdoc />
+    public virtual async Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context)
+    {
+        string? token = null;
+        if (context.Metadata.RequiredTokenType.HasValue)
+        {
+            var tokenType = context.Metadata.RequiredTokenType.Value;
+            token = await context.HttpContext.GetManagedAccessToken(tokenType, context.UserTokenRequestParameters);
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return new AccessTokenResult
+                {
+                    IsError = true
+                };
+            }
+        }
+
+        if (token == null)
+        {
+            if (context.Metadata.OptionalUserToken)
+            {
+                token = (await context.HttpContext.GetUserAccessTokenAsync(context.UserTokenRequestParameters)).AccessToken;
+            }
+
+        }
+        return new AccessTokenResult
+        {
+            Token = token,
+            IsError = false
+        };
+    }
+}

--- a/src/Duende.Bff/General/DefaultAccessTokenRetriever.cs
+++ b/src/Duende.Bff/General/DefaultAccessTokenRetriever.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Duende.Bff.Logging;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+
 namespace Duende.Bff;
 
 /// <summary>
@@ -10,6 +14,21 @@ namespace Duende.Bff;
 /// </summary>
 public class DefaultAccessTokenRetriever : IAccessTokenRetriever
 {
+
+    /// <summary>
+    /// The logger.
+    /// </summary>
+    protected readonly ILogger<DefaultAccessTokenRetriever> Logger;
+
+    /// <summary>
+    /// Creates new instances of DefaultAccessTokenRetriever. 
+    /// </summary>
+    /// <param name="logger"></param>
+    public DefaultAccessTokenRetriever(ILogger<DefaultAccessTokenRetriever> logger)
+    {
+        Logger = logger;
+    }
+
     /// <inheritdoc />
     public virtual async Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context)
     {
@@ -20,6 +39,7 @@ public class DefaultAccessTokenRetriever : IAccessTokenRetriever
             token = await context.HttpContext.GetManagedAccessToken(tokenType, context.UserTokenRequestParameters);
             if (string.IsNullOrWhiteSpace(token))
             {
+                Logger.AccessTokenMissing(context.LocalPath, tokenType);
                 return new AccessTokenResult
                 {
                     IsError = true

--- a/src/Duende.Bff/General/IAccessTokenRetriever.cs
+++ b/src/Duende.Bff/General/IAccessTokenRetriever.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Duende.Bff;
+
+/// <summary>
+/// Retrieves access tokens
+/// </summary>
+public interface IAccessTokenRetriever
+{
+    /// <summary>
+    /// Gets the access token
+    /// </summary>
+    /// <param name="context">Context used to retrieve the token</param>
+    /// <returns></returns>
+    Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context);
+}

--- a/src/Duende.Bff/General/Log.cs
+++ b/src/Duende.Bff/General/Log.cs
@@ -17,6 +17,7 @@ internal static class EventIds
     public static readonly EventId AntiForgeryValidationFailed = new (1, "AntiForgeryValidationFailed");
     public static readonly EventId BackChannelLogout = new (2, "BackChannelLogout");
     public static readonly EventId BackChannelLogoutError = new (3, "BackChannelLogoutError");
+    public static readonly EventId AccessTokenMissing = new (4, "AccessTokenMissing");
 }
     
 internal static class Log
@@ -36,6 +37,12 @@ internal static class Log
         EventIds.BackChannelLogoutError,
         "Back-channel logout error. error: '{error}'");
 
+    private static readonly Action<ILogger, string, string, Exception?> _accessTokenMissing = LoggerMessage.Define<string, string>(
+        LogLevel.Warning,
+        EventIds.AccessTokenMissing,
+        "Access token is missing. token type: '{tokenType}', local path: '{localpath}'.");
+
+
     public static void AntiForgeryValidationFailed(this ILogger logger, string localPath)
     {
         _antiForgeryValidationFailed(logger, localPath, null);
@@ -49,5 +56,10 @@ internal static class Log
     public static void BackChannelLogoutError(this ILogger logger, string error)
     { 
         _backChannelLogoutError(logger, error, null);
+    }
+
+    public static void AccessTokenMissing(this ILogger logger, string localPath, TokenType tokenType)
+    {
+        _accessTokenMissing(logger, tokenType.ToString(), localPath, null);
     }
 }

--- a/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -179,6 +179,33 @@ namespace Duende.Bff.Tests.Endpoints
         }
 
         [Fact]
+        public async Task calls_to_remote_endpoint_should_fail_when_token_retrieval_fails()
+        {
+            await BffHost.BffLoginAsync("alice");
+
+            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_with_access_token_retrieval_that_fails"));
+            req.Headers.Add("x-csrf", "1");
+            var response = await BffHost.BrowserClient.SendAsync(req);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task calls_to_remote_endpoint_should_send_token_from_token_retriever_when_token_retrieval_succeeds()
+        {
+            await BffHost.BffLoginAsync("alice");
+
+            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_with_access_token_retriever"));
+            req.Headers.Add("x-csrf", "1");
+            var response = await BffHost.BrowserClient.SendAsync(req);
+
+            var json = await response.Content.ReadAsStringAsync();
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            apiResult.Sub.Should().Be("123");
+            apiResult.ClientId.Should().Be("fake-client");
+        }
+
+        [Fact]
         public async Task calls_to_remote_endpoint_should_forward_user_or_client_to_api()
         {
             {

--- a/test/Duende.Bff.Tests/TestFramework/GenericHost.cs
+++ b/test/Duende.Bff.Tests/TestFramework/GenericHost.cs
@@ -113,8 +113,6 @@ namespace Duende.Bff.Tests.TestFramework
             ConfigureSignout(app);
         }
 
-
-
         void ConfigureSignout(IApplicationBuilder app)
         {
             app.Use(async (ctx, next) =>
@@ -129,12 +127,12 @@ namespace Duende.Bff.Tests.TestFramework
                 await next();
             });
         }
+
         public async Task RevokeSessionCookieAsync()
         {
             var response = await BrowserClient.GetAsync(Url("__signout"));
             response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         }
-
 
         void ConfigureSignin(IApplicationBuilder app)
         {

--- a/test/Duende.Bff.Tests/TestHosts/ApiHost.cs
+++ b/test/Duende.Bff.Tests/TestHosts/ApiHost.cs
@@ -91,8 +91,8 @@ namespace Duende.Bff.Tests.TestHosts
                     var response = new ApiResponse(
                         context.Request.Method,
                         context.Request.Path.Value,
-                        context.User.FindFirst(("sub"))?.Value,
-                        context.User.FindFirst(("client_id"))?.Value,
+                        context.User.FindFirst("sub")?.Value,
+                        context.User.FindFirst("client_id")?.Value,
                         context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
                     {
                         Body = body,

--- a/test/Duende.Bff.Tests/TestHosts/BffHost.cs
+++ b/test/Duende.Bff.Tests/TestHosts/BffHost.cs
@@ -156,8 +156,8 @@ namespace Duende.Bff.Tests.TestHosts
                         var response = new ApiResponse(
                             context.Request.Method,
                             context.Request.Path.Value,
-                            context.User.FindFirst(("sub"))?.Value,
-                            context.User.FindFirst(("client_id"))?.Value,
+                            context.User.FindFirst("sub")?.Value,
+                            context.User.FindFirst("client_id")?.Value,
                             context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
                         {
                             Body = body,
@@ -209,8 +209,8 @@ namespace Duende.Bff.Tests.TestHosts
                         var response = new ApiResponse(
                             context.Request.Method,
                             context.Request.Path.Value,
-                            context.User.FindFirst(("sub"))?.Value,
-                            context.User.FindFirst(("client_id"))?.Value,
+                            context.User.FindFirst("sub")?.Value,
+                            context.User.FindFirst("client_id")?.Value,
                             context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
                         {
                             Body = body,
@@ -263,8 +263,8 @@ namespace Duende.Bff.Tests.TestHosts
                     var response = new ApiResponse(
                         context.Request.Method,
                         context.Request.Path.Value,
-                        context.User.FindFirst(("sub"))?.Value,
-                        context.User.FindFirst(("client_id"))?.Value,
+                        context.User.FindFirst("sub")?.Value,
+                        context.User.FindFirst("client_id")?.Value,
                         context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
                     {
                         Body = body,
@@ -298,7 +298,7 @@ namespace Duende.Bff.Tests.TestHosts
 
                 endpoints.Map("/local_authz", async context =>
                     {
-                        var sub = context.User.FindFirst(("sub"))?.Value;
+                        var sub = context.User.FindFirst("sub")?.Value;
                         if (sub == null) throw new Exception("sub is missing");
 
                         var body = default(string);
@@ -314,7 +314,7 @@ namespace Duende.Bff.Tests.TestHosts
                             context.Request.Method,
                             context.Request.Path.Value,
                             sub,
-                            context.User.FindFirst(("client_id"))?.Value,
+                            context.User.FindFirst("client_id")?.Value,
                             context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
                         {
                             Body = body
@@ -345,7 +345,7 @@ namespace Duende.Bff.Tests.TestHosts
 
                 endpoints.Map("/local_authz_no_csrf", async context =>
                     {
-                        var sub = context.User.FindFirst(("sub"))?.Value;
+                        var sub = context.User.FindFirst("sub")?.Value;
                         if (sub == null) throw new Exception("sub is missing");
 
                         var body = default(string);
@@ -361,7 +361,7 @@ namespace Duende.Bff.Tests.TestHosts
                             context.Request.Method,
                             context.Request.Path.Value,
                             sub,
-                            context.User.FindFirst(("client_id"))?.Value,
+                            context.User.FindFirst("client_id")?.Value,
                             context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
                         {
                             Body = body

--- a/test/Duende.Bff.Tests/TestHosts/BffHost.cs
+++ b/test/Duende.Bff.Tests/TestHosts/BffHost.cs
@@ -18,229 +18,180 @@ using Duende.Bff.Yarp;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Authentication;
 
-namespace Duende.Bff.Tests.TestHosts
+namespace Duende.Bff.Tests.TestHosts;
+
+public class BffHost : GenericHost
 {
-    public class BffHost : GenericHost
+    public enum ResponseStatus
     {
-        public enum ResponseStatus
+        Ok, Challenge, Forbid
+    }
+    public ResponseStatus LocalApiResponseStatus { get; set; } = ResponseStatus.Ok;
+
+    private readonly IdentityServerHost _identityServerHost;
+    private readonly ApiHost _apiHost;
+    private readonly string _clientId;
+    private readonly bool _useForwardedHeaders;
+
+    public BffOptions BffOptions { get; private set; }
+
+    public BffHost(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
+        string baseAddress = "https://app", bool useForwardedHeaders = false)
+        : base(baseAddress)
+    {
+        _identityServerHost = identityServerHost;
+        _apiHost = apiHost;
+        _clientId = clientId;
+        _useForwardedHeaders = useForwardedHeaders;
+
+        OnConfigureServices += ConfigureServices;
+        OnConfigure += Configure;
+    }
+
+    private void ConfigureServices(IServiceCollection services)
+    {
+        services.AddRouting();
+        services.AddAuthorization();
+
+        var bff = services.AddBff(options =>
         {
-            Ok, Challenge, Forbid
-        }
-        public ResponseStatus LocalApiResponseStatus { get; set; } = ResponseStatus.Ok;
+            BffOptions = options;
+        });
 
-        private readonly IdentityServerHost _identityServerHost;
-        private readonly ApiHost _apiHost;
-        private readonly string _clientId;
-        private readonly bool _useForwardedHeaders;
+        services.AddSingleton<IHttpMessageInvokerFactory>(
+            new CallbackHttpMessageInvokerFactory(
+                path => new HttpMessageInvoker(_apiHost.Server.CreateHandler())));
 
-        public BffOptions BffOptions { get; private set; }
-
-        public BffHost(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
-            string baseAddress = "https://app", bool useForwardedHeaders = false)
-            : base(baseAddress)
-        {
-            _identityServerHost = identityServerHost;
-            _apiHost = apiHost;
-            _clientId = clientId;
-            _useForwardedHeaders = useForwardedHeaders;
-
-            OnConfigureServices += ConfigureServices;
-            OnConfigure += Configure;
-        }
-
-        private void ConfigureServices(IServiceCollection services)
-        {
-            services.AddRouting();
-            services.AddAuthorization();
-
-            var bff = services.AddBff(options =>
+        services.AddAuthentication("cookie")
+            .AddCookie("cookie", options =>
             {
-                BffOptions = options;
+                options.Cookie.Name = "bff";
             });
 
-            services.AddSingleton<IHttpMessageInvokerFactory>(
-                new CallbackHttpMessageInvokerFactory(
-                    path => new HttpMessageInvoker(_apiHost.Server.CreateHandler())));
+        bff.AddServerSideSessions();
+        bff.AddRemoteApis();
 
-            services.AddAuthentication("cookie")
-                .AddCookie("cookie", options =>
+        services.AddAuthentication(options =>
+            {
+                options.DefaultChallengeScheme = "oidc";
+                options.DefaultSignOutScheme = "oidc";
+            })
+            .AddOpenIdConnect("oidc", options =>
+            {
+                options.Authority = _identityServerHost.Url();
+
+                options.ClientId = _clientId;
+                options.ClientSecret = "secret";
+                options.ResponseType = "code";
+                options.ResponseMode = "query";
+
+                options.MapInboundClaims = false;
+                options.GetClaimsFromUserInfoEndpoint = true;
+                options.SaveTokens = true;
+
+                options.Scope.Clear();
+                var client = _identityServerHost.Clients.Single(x => x.ClientId == _clientId);
+                foreach (var scope in client.AllowedScopes)
                 {
-                    options.Cookie.Name = "bff";
-                });
+                    options.Scope.Add(scope);
+                }
 
-            bff.AddServerSideSessions();
-            bff.AddRemoteApis();
-
-            services.AddAuthentication(options =>
+                if (client.AllowOfflineAccess)
                 {
-                    options.DefaultChallengeScheme = "oidc";
-                    options.DefaultSignOutScheme = "oidc";
+                    options.Scope.Add("offline_access");
+                }
+
+                options.BackchannelHttpHandler = _identityServerHost.Server.CreateHandler();
+            });
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy("AlwaysFail", policy => { policy.RequireAssertion(ctx => false); });
+        });
+
+        services.AddSingleton<FailureAccessTokenRetriever>();
+
+        services.AddSingleton(new TestAccessTokenRetriever(async ()
+            => await _identityServerHost.CreateJwtAccessTokenAsync()));
+    }
+
+    private void Configure(IApplicationBuilder app)
+    {
+        if (_useForwardedHeaders)
+        {
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor |
+                                   ForwardedHeaders.XForwardedProto |
+                                   ForwardedHeaders.XForwardedHost
+            });
+        }
+
+        app.UseAuthentication();
+
+        app.UseRouting();
+
+        app.UseBff();
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapBffManagementEndpoints();
+
+            endpoints.Map("/local_anon", async context =>
+                {
+                    // capture body if present
+                    var body = default(string);
+                    if (context.Request.HasJsonContentType())
+                    {
+                        using (var sr = new StreamReader(context.Request.Body))
+                        {
+                            body = await sr.ReadToEndAsync();
+                        }
+                    }
+
+                    // capture request headers
+                    var requestHeaders = new Dictionary<string, List<string>>();
+                    foreach (var header in context.Request.Headers)
+                    {
+                        var values = new List<string>(header.Value.Select(v => v));
+                        requestHeaders.Add(header.Key, values);
+                    }
+
+                    var response = new ApiResponse(
+                        context.Request.Method,
+                        context.Request.Path.Value,
+                        context.User.FindFirst("sub")?.Value,
+                        context.User.FindFirst("client_id")?.Value,
+                        context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
+                    {
+                        Body = body,
+                        RequestHeaders = requestHeaders
+                    };
+
+                    if (LocalApiResponseStatus == ResponseStatus.Ok)
+                    {
+                        context.Response.StatusCode = 200;
+
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                    }
+                    else if (LocalApiResponseStatus == ResponseStatus.Challenge)
+                    {
+                        await context.ChallengeAsync();
+                    }
+                    else if (LocalApiResponseStatus == ResponseStatus.Forbid)
+                    {
+                        await context.ForbidAsync();
+                    }
+                    else
+                    {
+                        throw new Exception("Invalid LocalApiResponseStatus");
+                    }
                 })
-                .AddOpenIdConnect("oidc", options =>
-                {
-                    options.Authority = _identityServerHost.Url();
+                .AsBffApiEndpoint();
 
-                    options.ClientId = _clientId;
-                    options.ClientSecret = "secret";
-                    options.ResponseType = "code";
-                    options.ResponseMode = "query";
-
-                    options.MapInboundClaims = false;
-                    options.GetClaimsFromUserInfoEndpoint = true;
-                    options.SaveTokens = true;
-
-                    options.Scope.Clear();
-                    var client = _identityServerHost.Clients.Single(x => x.ClientId == _clientId);
-                    foreach (var scope in client.AllowedScopes)
-                    {
-                        options.Scope.Add(scope);
-                    }
-
-                    if (client.AllowOfflineAccess)
-                    {
-                        options.Scope.Add("offline_access");
-                    }
-
-                    options.BackchannelHttpHandler = _identityServerHost.Server.CreateHandler();
-                });
-
-            services.AddAuthorization(options =>
-            {
-                options.AddPolicy("AlwaysFail", policy => { policy.RequireAssertion(ctx => false); });
-            });
-        }
-
-        private void Configure(IApplicationBuilder app)
-        {
-            if (_useForwardedHeaders)
-            {
-                app.UseForwardedHeaders(new ForwardedHeadersOptions
-                {
-                    ForwardedHeaders = ForwardedHeaders.XForwardedFor |
-                                       ForwardedHeaders.XForwardedProto |
-                                       ForwardedHeaders.XForwardedHost
-                });
-            }
-
-            app.UseAuthentication();
-
-            app.UseRouting();
-
-            app.UseBff();
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapBffManagementEndpoints();
-
-                endpoints.Map("/local_anon", async context =>
-                    {
-                        // capture body if present
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
-
-                        // capture request headers
-                        var requestHeaders = new Dictionary<string, List<string>>();
-                        foreach (var header in context.Request.Headers)
-                        {
-                            var values = new List<string>(header.Value.Select(v => v));
-                            requestHeaders.Add(header.Key, values);
-                        }
-
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            context.User.FindFirst("sub")?.Value,
-                            context.User.FindFirst("client_id")?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body,
-                            RequestHeaders = requestHeaders
-                        };
-
-                        if (LocalApiResponseStatus == ResponseStatus.Ok)
-                        {
-                            context.Response.StatusCode = 200;
-
-                            context.Response.ContentType = "application/json";
-                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Challenge)
-                        {
-                            await context.ChallengeAsync();
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Forbid)
-                        {
-                            await context.ForbidAsync();
-                        }
-                        else
-                        {
-                            throw new Exception("Invalid LocalApiResponseStatus");
-                        }
-                    })
-                    .AsBffApiEndpoint();
-
-                endpoints.Map("/local_anon_no_csrf", async context =>
-                    {
-                        // capture body if present
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
-
-                        // capture request headers
-                        var requestHeaders = new Dictionary<string, List<string>>();
-                        foreach (var header in context.Request.Headers)
-                        {
-                            var values = new List<string>(header.Value.Select(v => v));
-                            requestHeaders.Add(header.Key, values);
-                        }
-
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            context.User.FindFirst("sub")?.Value,
-                            context.User.FindFirst("client_id")?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body,
-                            RequestHeaders = requestHeaders
-                        };
-
-                        if (LocalApiResponseStatus == ResponseStatus.Ok)
-                        {
-                            context.Response.StatusCode = 200;
-
-                            context.Response.ContentType = "application/json";
-                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Challenge)
-                        {
-                            await context.ChallengeAsync();
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Forbid)
-                        {
-                            await context.ForbidAsync();
-                        }
-                        else
-                        {
-                            throw new Exception("Invalid LocalApiResponseStatus");
-                        }
-                    })
-                    .AsBffApiEndpoint()
-                    .SkipAntiforgery();
-
-                endpoints.Map("/local_anon_no_csrf_no_response_handling", async context =>
+            endpoints.Map("/local_anon_no_csrf", async context =>
                 {
                     // capture body if present
                     var body = default(string);
@@ -292,240 +243,303 @@ namespace Duende.Bff.Tests.TestHosts
                     }
                 })
                 .AsBffApiEndpoint()
+                .SkipAntiforgery();
+
+            endpoints.Map("/local_anon_no_csrf_no_response_handling", async context =>
+            {
+                // capture body if present
+                var body = default(string);
+                if (context.Request.HasJsonContentType())
+                {
+                    using (var sr = new StreamReader(context.Request.Body))
+                    {
+                        body = await sr.ReadToEndAsync();
+                    }
+                }
+
+                // capture request headers
+                var requestHeaders = new Dictionary<string, List<string>>();
+                foreach (var header in context.Request.Headers)
+                {
+                    var values = new List<string>(header.Value.Select(v => v));
+                    requestHeaders.Add(header.Key, values);
+                }
+
+                var response = new ApiResponse(
+                    context.Request.Method,
+                    context.Request.Path.Value,
+                    context.User.FindFirst("sub")?.Value,
+                    context.User.FindFirst("client_id")?.Value,
+                    context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
+                {
+                    Body = body,
+                    RequestHeaders = requestHeaders
+                };
+
+                if (LocalApiResponseStatus == ResponseStatus.Ok)
+                {
+                    context.Response.StatusCode = 200;
+
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                }
+                else if (LocalApiResponseStatus == ResponseStatus.Challenge)
+                {
+                    await context.ChallengeAsync();
+                }
+                else if (LocalApiResponseStatus == ResponseStatus.Forbid)
+                {
+                    await context.ForbidAsync();
+                }
+                else
+                {
+                    throw new Exception("Invalid LocalApiResponseStatus");
+                }
+            })
+            .AsBffApiEndpoint()
+            .SkipAntiforgery()
+            .SkipResponseHandling();
+
+
+            endpoints.Map("/local_authz", async context =>
+                {
+                    var sub = context.User.FindFirst("sub")?.Value;
+                    if (sub == null) throw new Exception("sub is missing");
+
+                    var body = default(string);
+                    if (context.Request.HasJsonContentType())
+                    {
+                        using (var sr = new StreamReader(context.Request.Body))
+                        {
+                            body = await sr.ReadToEndAsync();
+                        }
+                    }
+
+                    var response = new ApiResponse(
+                        context.Request.Method,
+                        context.Request.Path.Value,
+                        sub,
+                        context.User.FindFirst("client_id")?.Value,
+                        context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
+                    {
+                        Body = body
+                    };
+
+                    if (LocalApiResponseStatus == ResponseStatus.Ok)
+                    {
+                        context.Response.StatusCode = 200;
+
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                    }
+                    else if (LocalApiResponseStatus == ResponseStatus.Challenge)
+                    {
+                        await context.ChallengeAsync();
+                    }
+                    else if (LocalApiResponseStatus == ResponseStatus.Forbid)
+                    {
+                        await context.ForbidAsync();
+                    }
+                    else
+                    {
+                        throw new Exception("Invalid LocalApiResponseStatus");
+                    }
+                })
+                .RequireAuthorization()
+                .AsBffApiEndpoint();
+
+            endpoints.Map("/local_authz_no_csrf", async context =>
+                {
+                    var sub = context.User.FindFirst("sub")?.Value;
+                    if (sub == null) throw new Exception("sub is missing");
+
+                    var body = default(string);
+                    if (context.Request.HasJsonContentType())
+                    {
+                        using (var sr = new StreamReader(context.Request.Body))
+                        {
+                            body = await sr.ReadToEndAsync();
+                        }
+                    }
+
+                    var response = new ApiResponse(
+                        context.Request.Method,
+                        context.Request.Path.Value,
+                        sub,
+                        context.User.FindFirst("client_id")?.Value,
+                        context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
+                    {
+                        Body = body
+                    };
+
+                    if (LocalApiResponseStatus == ResponseStatus.Ok)
+                    {
+                        context.Response.StatusCode = 200;
+
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                    }
+                    else if (LocalApiResponseStatus == ResponseStatus.Challenge)
+                    {
+                        await context.ChallengeAsync();
+                    }
+                    else if (LocalApiResponseStatus == ResponseStatus.Forbid)
+                    {
+                        await context.ForbidAsync();
+                    }
+                    else
+                    {
+                        throw new Exception("Invalid LocalApiResponseStatus");
+                    }
+                })
+                .RequireAuthorization()
+                .AsBffApiEndpoint()
+                .SkipAntiforgery();
+
+
+            endpoints.Map("/always_fail_authz_non_bff_endpoint", context => { return Task.CompletedTask; })
+                .RequireAuthorization("AlwaysFail");
+
+            endpoints.Map("/always_fail_authz", context => { return Task.CompletedTask; })
+                .AsBffApiEndpoint()
+                .RequireAuthorization("AlwaysFail");
+
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_user", _apiHost.Url())
+                .RequireAccessToken();
+
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_user_no_csrf", _apiHost.Url())
                 .SkipAntiforgery()
-                .SkipResponseHandling();
+                .RequireAccessToken();
 
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_client", _apiHost.Url())
+                .RequireAccessToken(TokenType.Client);
 
-                endpoints.Map("/local_authz", async context =>
-                    {
-                        var sub = context.User.FindFirst("sub")?.Value;
-                        if (sub == null) throw new Exception("sub is missing");
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_user_or_client", _apiHost.Url())
+                .RequireAccessToken(TokenType.UserOrClient);
 
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_user_or_anon", _apiHost.Url())
+                .WithOptionalUserAccessToken();
 
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            sub,
-                            context.User.FindFirst("client_id")?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body
-                        };
+            endpoints.MapRemoteBffApiEndpoint(
+                "/api_anon_only", _apiHost.Url());
 
-                        if (LocalApiResponseStatus == ResponseStatus.Ok)
-                        {
-                            context.Response.StatusCode = 200;
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_with_access_token_retriever", _apiHost.Url())
+                .RequireAccessToken(TokenType.UserOrClient)
+                .WithAccessTokenRetriever<TestAccessTokenRetriever>();
 
-                            context.Response.ContentType = "application/json";
-                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Challenge)
-                        {
-                            await context.ChallengeAsync();
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Forbid)
-                        {
-                            await context.ForbidAsync();
-                        }
-                        else
-                        {
-                            throw new Exception("Invalid LocalApiResponseStatus");
-                        }
-                    })
-                    .RequireAuthorization()
-                    .AsBffApiEndpoint();
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_with_access_token_retrieval_that_fails", _apiHost.Url())
+                .RequireAccessToken(TokenType.UserOrClient)
+                .WithAccessTokenRetriever<FailureAccessTokenRetriever>();
 
-                endpoints.Map("/local_authz_no_csrf", async context =>
-                    {
-                        var sub = context.User.FindFirst("sub")?.Value;
-                        if (sub == null) throw new Exception("sub is missing");
+            endpoints.Map(
+                "/not_bff_endpoint",
+                RemoteApiEndpoint.Map("/not_bff_endpoint", _apiHost.Url()));
+        });
 
-                        var body = default(string);
-                        if (context.Request.HasJsonContentType())
-                        {
-                            using (var sr = new StreamReader(context.Request.Body))
-                            {
-                                body = await sr.ReadToEndAsync();
-                            }
-                        }
+        app.Map("/invalid_endpoint",
+            invalid => invalid.Use(next => RemoteApiEndpoint.Map("/invalid_endpoint", _apiHost.Url())));
+    }
 
-                        var response = new ApiResponse(
-                            context.Request.Method,
-                            context.Request.Path.Value,
-                            sub,
-                            context.User.FindFirst("client_id")?.Value,
-                            context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-                        {
-                            Body = body
-                        };
+    public async Task<bool> GetIsUserLoggedInAsync(string userQuery = null)
+    {
+        if (userQuery != null) userQuery = "?" + userQuery;
 
-                        if (LocalApiResponseStatus == ResponseStatus.Ok)
-                        {
-                            context.Response.StatusCode = 200;
+        var req = new HttpRequestMessage(HttpMethod.Get, Url("/bff/user") + userQuery);
+        req.Headers.Add("x-csrf", "1");
+        var response = await BrowserClient.SendAsync(req);
 
-                            context.Response.ContentType = "application/json";
-                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Challenge)
-                        {
-                            await context.ChallengeAsync();
-                        }
-                        else if (LocalApiResponseStatus == ResponseStatus.Forbid)
-                        {
-                            await context.ForbidAsync();
-                        }
-                        else
-                        {
-                            throw new Exception("Invalid LocalApiResponseStatus");
-                        }
-                    })
-                    .RequireAuthorization()
-                    .AsBffApiEndpoint()
-                    .SkipAntiforgery();
+        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized).Should()
+            .BeTrue();
 
+        return response.StatusCode == HttpStatusCode.OK;
+    }
 
-                endpoints.Map("/always_fail_authz_non_bff_endpoint", context => { return Task.CompletedTask; })
-                    .RequireAuthorization("AlwaysFail");
+    public async Task<List<JsonRecord>> CallUserEndpointAsync()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, Url("/bff/user"));
+        req.Headers.Add("x-csrf", "1");
 
-                endpoints.Map("/always_fail_authz", context => { return Task.CompletedTask; })
-                    .AsBffApiEndpoint()
-                    .RequireAuthorization("AlwaysFail");
+        var response = await BrowserClient.SendAsync(req);
 
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user", _apiHost.Url())
-                    .RequireAccessToken();
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
 
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user_no_csrf", _apiHost.Url())
-                    .SkipAntiforgery()
-                    .RequireAccessToken();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<List<JsonRecord>>(json);
+    }
 
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_client", _apiHost.Url())
-                    .RequireAccessToken(TokenType.Client);
+    public async Task<HttpResponseMessage> BffLoginAsync(string sub, string sid = null)
+    {
+        await _identityServerHost.CreateIdentityServerSessionCookieAsync(sub, sid);
+        return await BffOidcLoginAsync();
+    }
 
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user_or_client", _apiHost.Url())
-                    .RequireAccessToken(TokenType.UserOrClient);
+    public async Task<HttpResponseMessage> BffOidcLoginAsync()
+    {
+        var response = await BrowserClient.GetAsync(Url("/bff/login"));
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // authorize
+        response.Headers.Location.ToString().ToLowerInvariant().Should()
+            .StartWith(_identityServerHost.Url("/connect/authorize"));
 
-                endpoints.MapRemoteBffApiEndpoint(
-                        "/api_user_or_anon", _apiHost.Url())
-                    .WithOptionalUserAccessToken();
+        response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // client callback
+        response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signin-oidc"));
 
-                endpoints.MapRemoteBffApiEndpoint(
-                    "/api_anon_only", _apiHost.Url());
+        response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
+        response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
 
-                endpoints.Map(
-                    "/not_bff_endpoint",
-                    RemoteApiEndpoint.Map("/not_bff_endpoint", _apiHost.Url()));
-            });
+        (await GetIsUserLoggedInAsync()).Should().BeTrue();
 
-            app.Map("/invalid_endpoint",
-                invalid => invalid.Use(next => RemoteApiEndpoint.Map("/invalid_endpoint", _apiHost.Url())));
+        response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
+        return response;
+    }
+
+    public async Task<HttpResponseMessage> BffLogoutAsync(string sid = null)
+    {
+        var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
+        response.Headers.Location.ToString().ToLowerInvariant().Should()
+            .StartWith(_identityServerHost.Url("/connect/endsession"));
+
+        response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // logout
+        response.Headers.Location.ToString().ToLowerInvariant().Should()
+            .StartWith(_identityServerHost.Url("/account/logout"));
+
+        response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // post logout redirect uri
+        response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signout-callback-oidc"));
+
+        response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
+        response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+
+        (await GetIsUserLoggedInAsync()).Should().BeFalse();
+
+        response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
+        return response;
+    }
+
+    public class CallbackHttpMessageInvokerFactory : IHttpMessageInvokerFactory
+    {
+        public CallbackHttpMessageInvokerFactory(Func<string, HttpMessageInvoker> callback)
+        {
+            CreateInvoker = callback;
         }
 
-        public async Task<bool> GetIsUserLoggedInAsync(string userQuery = null)
+        public Func<string, HttpMessageInvoker> CreateInvoker { get; set; }
+
+        public HttpMessageInvoker CreateClient(string localPath)
         {
-            if (userQuery != null) userQuery = "?" + userQuery;
-
-            var req = new HttpRequestMessage(HttpMethod.Get, Url("/bff/user") + userQuery);
-            req.Headers.Add("x-csrf", "1");
-            var response = await BrowserClient.SendAsync(req);
-
-            (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized).Should()
-                .BeTrue();
-
-            return response.StatusCode == HttpStatusCode.OK;
-        }
-
-        public async Task<List<JsonRecord>> CallUserEndpointAsync()
-        {
-            var req = new HttpRequestMessage(HttpMethod.Get, Url("/bff/user"));
-            req.Headers.Add("x-csrf", "1");
-
-            var response = await BrowserClient.SendAsync(req);
-
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
-
-            var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<List<JsonRecord>>(json);
-        }
-
-        public async Task<HttpResponseMessage> BffLoginAsync(string sub, string sid = null)
-        {
-            await _identityServerHost.CreateIdentityServerSessionCookieAsync(sub, sid);
-            return await BffOidcLoginAsync();
-        }
-
-        public async Task<HttpResponseMessage> BffOidcLoginAsync()
-        {
-            var response = await BrowserClient.GetAsync(Url("/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // authorize
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/connect/authorize"));
-
-            response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // client callback
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signin-oidc"));
-
-            response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
-
-            (await GetIsUserLoggedInAsync()).Should().BeTrue();
-
-            response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
-            return response;
-        }
-
-        public async Task<HttpResponseMessage> BffLogoutAsync(string sid = null)
-        {
-            var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/connect/endsession"));
-
-            response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // logout
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/account/logout"));
-
-            response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // post logout redirect uri
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signout-callback-oidc"));
-
-            response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
-
-            (await GetIsUserLoggedInAsync()).Should().BeFalse();
-
-            response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
-            return response;
-        }
-
-        public class CallbackHttpMessageInvokerFactory : IHttpMessageInvokerFactory
-        {
-            public CallbackHttpMessageInvokerFactory(Func<string, HttpMessageInvoker> callback)
-            {
-                CreateInvoker = callback;
-            }
-
-            public Func<string, HttpMessageInvoker> CreateInvoker { get; set; }
-
-            public HttpMessageInvoker CreateClient(string localPath)
-            {
-                return CreateInvoker.Invoke(localPath);
-            }
+            return CreateInvoker.Invoke(localPath);
         }
     }
 }

--- a/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
+++ b/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
@@ -40,6 +40,8 @@ namespace Duende.Bff.Tests.TestHosts
                         BffHost.HttpClient, 
                         provider.GetRequiredService<ILoggerFactory>(), 
                         provider.GetRequiredService<ICancellationTokenProvider>()));
+
+                services.AddSingleton<DefaultAccessTokenRetriever>();
             };
             
             IdentityServerHost.InitializeAsync().Wait();

--- a/test/Duende.Bff.Tests/TestHosts/FailureAccessTokenRetriever.cs
+++ b/test/Duende.Bff.Tests/TestHosts/FailureAccessTokenRetriever.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Duende.Bff.Tests.TestHosts;
+
+public class FailureAccessTokenRetriever : IAccessTokenRetriever
+{
+    public Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context)
+    {
+        return Task.FromResult(new AccessTokenResult
+        {
+            IsError = true,
+        });
+    }
+}

--- a/test/Duende.Bff.Tests/TestHosts/TestAccessTokenRetriever.cs
+++ b/test/Duende.Bff.Tests/TestHosts/TestAccessTokenRetriever.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Duende.Bff.Tests.TestHosts;
+
+public class TestAccessTokenRetriever : IAccessTokenRetriever
+{
+    public TestAccessTokenRetriever(Func<Task<string>> accessTokenGetter)
+    {
+        _accessTokenGetter = accessTokenGetter;
+    }
+
+    private Func<Task<string>> _accessTokenGetter { get; set; }
+
+    public async Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context)
+    {
+        var token = await _accessTokenGetter();
+        return new AccessTokenResult
+        {
+            IsError = false,
+            Token = token
+        };
+    }
+}


### PR DESCRIPTION
This PR adds a new abstraction for describing how a BFF endpoint should retrieve access tokens. The intention is to allow for more flexibility when mapping remote bff api endpoints, without needing to drop into the complexity of YARP.

Usage of the abstraction looks like this:
```cs
endpoints.MapRemoteBffApiEndpoint("/api/impersonation", "https://localhost:5010")
                .RequireAccessToken(TokenType.UserOrClient)
                .WithAccessTokenRetriever<ImpersonationAccessTokenRetriever>();
```

On a per endpoint basis, you specify the mechanism for access token retrieval. If you don't specify, you get a default retriever with the same behavior as you would get today.

Access token retrievers look like this:

```c#
public interface IAccessTokenRetriever
{
    Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context);
}
```

You're passed a context object containing the http context and metadata, etc, and return a result containing a token.

The main use case that I have in mind for this came from a support issue where the user wanted to perform token exchange before calling apis.