### PR TITLE
update AccessTokenManagement

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,7 +19,7 @@
 
         <!-- runtime -->
         <PackageReference Update="IdentityModel" Version="6.1.0" />
-        <PackageReference Update="Duende.AccessTokenManagement.OpenIdConnect" Version="2.0.1" />
+        <PackageReference Update="Duende.AccessTokenManagement.OpenIdConnect" Version="2.0.2" />
         <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(FrameworkVersionRuntime)" />
         <PackageReference Update="Yarp.ReverseProxy" Version="$(YarpVersion)" />
 


### PR DESCRIPTION
There was a bug in the AccessTokenManagement library that prevented resource indicators from working. This updates to the fix.