### PR TITLE
Upgrade Yarp Reverse proxy

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,13 +3,13 @@
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
         <FrameworkVersionRuntime>6.0.0</FrameworkVersionRuntime>
         <FrameworkVersionTesting>6.0.11</FrameworkVersionTesting>
-        <YarpVersion>2.0.0</YarpVersion>
+        <YarpVersion>2.0.1</YarpVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0'">
         <FrameworkVersionRuntime>7.0.0</FrameworkVersionRuntime>
         <FrameworkVersionTesting>7.0.0</FrameworkVersionTesting>
-        <YarpVersion>2.0.0</YarpVersion>
+        <YarpVersion>2.0.1</YarpVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**

Upgrading Default version of Yarp.ReverseProxy to make sure version 2.0.0 is not referenced as peer dependency.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
