### PR TITLE
Using Duende.IdentityModel and update package references.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,7 +15,8 @@
         <!-- runtime -->
         <PackageReference Update="Duende.IdentityModel" Version="7.0.0" />
         <PackageReference Update="Duende.AccessTokenManagement.OpenIdConnect" Version="3.1.0-preview.1" />
-        <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(FrameworkVersionRuntime)" />
+        <!-- Need this version because so 'Microsoft.Extensions.Caching.Memory' is at least 8.0.1 that addresses known high severity vulnerability -->
+        <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
         <PackageReference Update="Microsoft.Extensions.Http" Version="$(FrameworkVersionRuntime)" />
         <PackageReference Update="Microsoft.AspNetCore.Components.WebAssembly" Version="$(FrameworkVersionRuntime)" />
         <PackageReference Update="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(FrameworkVersionRuntime)"  />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,8 +13,8 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 
         <!-- runtime -->
-        <PackageReference Update="IdentityModel" Version="7.0.0" />
-        <PackageReference Update="Duende.AccessTokenManagement.OpenIdConnect" Version="3.0.0" />
+        <PackageReference Update="Duende.IdentityModel" Version="7.0.0" />
+        <PackageReference Update="Duende.AccessTokenManagement.OpenIdConnect" Version="3.1.0-preview.1" />
         <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(FrameworkVersionRuntime)" />
         <PackageReference Update="Microsoft.Extensions.Http" Version="$(FrameworkVersionRuntime)" />
         <PackageReference Update="Microsoft.AspNetCore.Components.WebAssembly" Version="$(FrameworkVersionRuntime)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,7 @@
         <FrameworkVersionTesting>8.0.11</FrameworkVersionTesting>
         <WilsonVersion>8.0.1</WilsonVersion>
         <YarpVersion>2.1.0</YarpVersion>
-        <IdentityServerVersion>7.0.6</IdentityServerVersion>
+        <IdentityServerVersion>7.1.0-preview.1</IdentityServerVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,7 +24,7 @@
         <PackageReference Update="Yarp.ReverseProxy" Version="$(YarpVersion)" />
 
         <!-- samples -->
-        <PackageReference Update="Serilog.AspNetCore" Version="8.0.2" />
+        <PackageReference Update="Serilog.AspNetCore" Version="8.0.3" />
         <PackageReference Update="Microsoft.IdentityModel.JsonWebTokens" Version="$(WilsonVersion)" />
         <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="$(WilsonVersion)" />
 
@@ -38,14 +38,14 @@
         <PackageReference Update="Duende.IdentityServer" Version="$(IdentityServerVersion)" />
         
         <PackageReference Update="CsQuery.NETStandard" Version="1.3.6.1" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-        <PackageReference Update="xunit" Version="2.4.2" />
-        <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Update="xunit" Version="2.9.2" />
+        <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Update="FluentAssertions" Version="6.7.0" />
-        <PackageReference Update="coverlet.collector" Version="3.1.2">
+        <PackageReference Update="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
 <Project>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
         <FrameworkVersionRuntime>8.0.0</FrameworkVersionRuntime>
-        <FrameworkVersionTesting>8.0.8</FrameworkVersionTesting>
-        <WilsonVersion>7.1.2</WilsonVersion> <!-- Used in samples -->
+        <FrameworkVersionTesting>8.0.11</FrameworkVersionTesting>
+        <WilsonVersion>8.0.1</WilsonVersion>
         <YarpVersion>2.1.0</YarpVersion>
         <IdentityServerVersion>7.0.6</IdentityServerVersion>
     </PropertyGroup>

--- a/Duende.Bff.v3.ncrunchsolution
+++ b/Duende.Bff.v3.ncrunchsolution
@@ -1,0 +1,8 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <EnableRDI>True</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/migrations/UserSessionDb/UserSessionDb.csproj
+++ b/migrations/UserSessionDb/UserSessionDb.csproj
@@ -9,8 +9,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Apis/Api.DPoP/Api.DPoP.csproj
+++ b/samples/Apis/Api.DPoP/Api.DPoP.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel" />
+        <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Serilog.AspNetCore" />
     </ItemGroup>

--- a/samples/Apis/Api.DPoP/DPoP/DPoPExtensions.cs
+++ b/samples/Apis/Api.DPoP/DPoP/DPoPExtensions.cs
@@ -1,4 +1,4 @@
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;

--- a/samples/Apis/Api.DPoP/DPoP/DPoPJwtBearerEvents.cs
+++ b/samples/Apis/Api.DPoP/DPoP/DPoPJwtBearerEvents.cs
@@ -1,11 +1,11 @@
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using static IdentityModel.OidcConstants;
+using static Duende.IdentityModel.OidcConstants;
 
 namespace Api.DPoP;
 

--- a/samples/Apis/Api.DPoP/DPoP/DPoPProofValidator.cs
+++ b/samples/Apis/Api.DPoP/DPoP/DPoPProofValidator.cs
@@ -1,4 +1,4 @@
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/samples/Apis/Api.Isolated/Api.Isolated.csproj
+++ b/samples/Apis/Api.Isolated/Api.Isolated.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel" />
+        <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Serilog.AspNetCore" />
     </ItemGroup>

--- a/samples/Apis/Api/Api.csproj
+++ b/samples/Apis/Api/Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel" />
+        <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Serilog.AspNetCore" />
     </ItemGroup>

--- a/samples/IdentityServer/Config.cs
+++ b/samples/IdentityServer/Config.cs
@@ -3,7 +3,7 @@
 
 
 using Duende.IdentityServer.Models;
-using IdentityModel;
+using Duende.IdentityModel;
 
 namespace IdentityServerHost
 {

--- a/samples/IdentityServer/IdentityServer.csproj
+++ b/samples/IdentityServer/IdentityServer.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Duende.IdentityServer" />
+    <PackageReference Include="Duende.IdentityModel" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 

--- a/samples/IdentityServer/Pages/Account/Logout/Index.cshtml.cs
+++ b/samples/IdentityServer/Pages/Account/Logout/Index.cshtml.cs
@@ -1,7 +1,7 @@
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/samples/IdentityServer/Pages/Consent/Index.cshtml.cs
+++ b/samples/IdentityServer/Pages/Consent/Index.cshtml.cs
@@ -3,7 +3,7 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/samples/IdentityServer/Pages/Diagnostics/ViewModel.cs
+++ b/samples/IdentityServer/Pages/Diagnostics/ViewModel.cs
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using System.Text;
 using System.Text.Json;

--- a/samples/IdentityServer/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/samples/IdentityServer/Pages/ExternalLogin/Callback.cshtml.cs
@@ -3,7 +3,7 @@ using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Test;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/samples/IdentityServer/Pages/TestUsers.cs
+++ b/samples/IdentityServer/Pages/TestUsers.cs
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityServer;

--- a/samples/IdentityServer/TokenExchangeGrantValidator.cs
+++ b/samples/IdentityServer/TokenExchangeGrantValidator.cs
@@ -1,6 +1,6 @@
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
+using Duende.IdentityModel;
 
 namespace IdentityServerHost;
 

--- a/samples/JS8.EF/JS8.EF.csproj
+++ b/samples/JS8.EF/JS8.EF.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 

--- a/samples/JS8/ImpersonationAccessTokenRetriever.cs
+++ b/samples/JS8/ImpersonationAccessTokenRetriever.cs
@@ -4,8 +4,8 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Duende.Bff;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using Microsoft.Extensions.Logging;
 
 namespace Host8;

--- a/src/Duende.Bff.Blazor.Client/Duende.Bff.Blazor.Client.csproj
+++ b/src/Duende.Bff.Blazor.Client/Duende.Bff.Blazor.Client.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <!-- Explicitly taking this version so that we don't pull in vulnerable old versions. -->
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Duende.Bff.Blazor/BffServerAuthenticationStateProvider.cs
+++ b/src/Duende.Bff.Blazor/BffServerAuthenticationStateProvider.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Security.Claims;
 using Duende.Bff.Blazor.Client;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server;

--- a/src/Duende.Bff.Yarp/AccessTokenRequestTransform.cs
+++ b/src/Duende.Bff.Yarp/AccessTokenRequestTransform.cs
@@ -6,7 +6,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Duende.AccessTokenManagement;
 using Duende.Bff.Logging;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.Extensions.Logging;
 using Yarp.ReverseProxy.Transforms;
 

--- a/src/Duende.Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
+++ b/src/Duende.Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;

--- a/src/Duende.Bff/EndpointServices/Logout/DefaultLogoutService.cs
+++ b/src/Duende.Bff/EndpointServices/Logout/DefaultLogoutService.cs
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using Duende.AccessTokenManagement.OpenIdConnect;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/src/Duende.Bff/EndpointServices/SilentLogin/DefaultSilentLoginCallbackService.cs
+++ b/src/Duende.Bff/EndpointServices/SilentLogin/DefaultSilentLoginCallbackService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/src/Duende.Bff/EndpointServices/User/DefaultClaimsService.cs
+++ b/src/Duende.Bff/EndpointServices/User/DefaultClaimsService.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;

--- a/src/Duende.Bff/Extensions/AuthenticationTicketExtensions.cs
+++ b/src/Duende.Bff/Extensions/AuthenticationTicketExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;

--- a/src/Duende.Bff/Extensions/HttpContextExtensions.cs
+++ b/src/Duende.Bff/Extensions/HttpContextExtensions.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 

--- a/src/Duende.Bff/General/DefaultAccessTokenRetriever.cs
+++ b/src/Duende.Bff/General/DefaultAccessTokenRetriever.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Duende.Bff.Logging;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 

--- a/src/Duende.Bff/SessionManagement/Configuration/PostConfigureApplicationCookieRevokeRefreshToken.cs
+++ b/src/Duende.Bff/SessionManagement/Configuration/PostConfigureApplicationCookieRevokeRefreshToken.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Logging;

--- a/src/Duende.Bff/SessionManagement/TicketStore/ServerSideTicketStore.cs
+++ b/src/Duende.Bff/SessionManagement/TicketStore/ServerSideTicketStore.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;

--- a/test/Duende.Bff.Blazor.Client.UnitTests/Duende.Bff.Blazor.Client.UnitTests.csproj
+++ b/test/Duende.Bff.Blazor.Client.UnitTests/Duende.Bff.Blazor.Client.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -12,11 +12,11 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Duende.Bff.Blazor.UnitTests/Duende.Bff.Blazor.UnitTests.csproj
+++ b/test/Duende.Bff.Blazor.UnitTests/Duende.Bff.Blazor.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -393,7 +393,7 @@ namespace Duende.Bff.Tests.Endpoints
                     opts.DPoPJsonWebKey = jwk;
                 });
             };
-            BffHost.InitializeAsync().Wait();
+            await BffHost.InitializeAsync();
 
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_client/test"));
             req.Headers.Add("x-csrf", "1");

--- a/test/Duende.Bff.Tests/TestHosts/IdentityServerHost.cs
+++ b/test/Duende.Bff.Tests/TestHosts/IdentityServerHost.cs
@@ -6,7 +6,7 @@ using Duende.Bff.Tests.TestFramework;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
- Replace IdentityModel with Duende.IdentityModel, update namespaces etc.
- Update EF package references
- Update test related package references and use central versions
- Bump System.Text.Json version because of vulnerability
- Update framework testing version to 8.0.11 to solve vuln warnings.
- Set minimum version 
- Use latest preview version of IdentityServer
