### PR TITLE
Remove csquery package refrence and unused code

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,7 +38,6 @@
         
         <PackageReference Update="Duende.IdentityServer" Version="$(IdentityServerVersion)" />
         
-        <PackageReference Update="AngleSharp" Version="1.1.2" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Update="xunit" Version="2.9.2" />
         <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,7 +38,7 @@
         
         <PackageReference Update="Duende.IdentityServer" Version="$(IdentityServerVersion)" />
         
-        <PackageReference Update="CsQuery.NETStandard" Version="1.3.6.1" />
+        <PackageReference Update="AngleSharp" Version="1.1.2" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Update="xunit" Version="2.9.2" />
         <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">

--- a/test/Duende.Bff.Tests/Duende.Bff.Tests.csproj
+++ b/test/Duende.Bff.Tests/Duende.Bff.Tests.csproj
@@ -16,7 +16,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CsQuery.NETStandard" />
   
     <PackageReference Include="Duende.IdentityServer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/test/Duende.Bff.Tests/TestFramework/TestBrowserClient.cs
+++ b/test/Duende.Bff.Tests/TestFramework/TestBrowserClient.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using CsQuery;
-using FluentAssertions;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -67,208 +63,16 @@ namespace Duende.Bff.Tests.TestFramework
             _handler = handler;
         }
 
-        public Cookie GetCookie(string name)
-        {
-            return GetCookie(_handler.CurrentUri.ToString(), name);
-        }
-        public Cookie GetCookie(string uri, string name)
-        {
-            return _handler.CookieContainer.GetCookies(new Uri(uri)).Cast<Cookie>().Where(x => x.Name == name).FirstOrDefault();
-        }
-
         public void RemoveCookie(string name)
         {
             RemoveCookie(CurrentUri.ToString(), name);
         }
         public void RemoveCookie(string uri, string name)
         {
-            var cookie = CookieContainer.GetCookies(new Uri(uri)).Cast<Cookie>().Where(x => x.Name == name).FirstOrDefault();
+            var cookie = CookieContainer.GetCookies(new Uri(uri)).FirstOrDefault(x => x.Name == name);
             if (cookie != null)
             {
                 cookie.Expired = true;
-            }
-        }
-
-        public async Task FollowRedirectAsync()
-        {
-            LastResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            var location = LastResponse.Headers.Location.ToString();
-            await GetAsync(location);
-        }
-
-        public Task<HttpResponseMessage> PostFormAsync(HtmlForm form)
-        {
-            return PostAsync(form.Action, new FormUrlEncodedContent(form.Inputs));
-        }
-
-        public Task<HtmlForm> ReadFormAsync(string selector = null)
-        {
-            return ReadFormAsync(LastResponse, selector);
-        }
-        public async Task<HtmlForm> ReadFormAsync(HttpResponseMessage response, string selector = null)
-        {
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-            var htmlForm = new HtmlForm
-            {
-
-            };
-
-            var html = await response.Content.ReadAsStringAsync();
-
-            var dom = new CQ(html);
-            var form = dom.Find(selector ?? "form");
-            form.Length.Should().Be(1);
-
-            var postUrl = form.Attr("action");
-            if (!postUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            {
-                if (postUrl.StartsWith("/"))
-                {
-                    postUrl = CurrentUri.Scheme + "://" + CurrentUri.Authority + postUrl;
-                }
-                else
-                {
-                    postUrl = CurrentUri + postUrl;
-                }
-            }
-            htmlForm.Action = postUrl;
-
-
-            var data = new Dictionary<string, string>();
-
-            var inputs = form.Find("input");
-            foreach (var input in inputs)
-            {
-                var name = input.GetAttribute("name");
-                var value = input.GetAttribute("value");
-
-                if (!data.ContainsKey(name))
-                {
-                    data.Add(name, value);
-                }
-                else
-                {
-                    data[name] = value;
-                }
-            }
-            htmlForm.Inputs = data;
-
-            return htmlForm;
-        }
-
-
-        public Task<string> ReadElementTextAsync(string selector)
-        {
-            return ReadElementTextAsync(LastResponse, selector);
-        }
-        public async Task<string> ReadElementTextAsync(HttpResponseMessage response, string selector)
-        {
-            var html = await response.Content.ReadAsStringAsync();
-
-            var dom = new CQ(html);
-            var element = dom.Find(selector);
-            return element.Text();
-        }
-
-        public Task<string> ReadElementAttributeAsync(string selector, string attribute)
-        {
-            return ReadElementAttributeAsync(LastResponse, selector, attribute);
-        }
-        public async Task<string> ReadElementAttributeAsync(HttpResponseMessage response, string selector, string attribute)
-        {
-            var html = await response.Content.ReadAsStringAsync();
-
-            var dom = new CQ(html);
-            var element = dom.Find(selector);
-            return element.Attr(attribute);
-        }
-
-        public Task AssertExistsAsync(string selector)
-        {
-            return AssertExistsAsync(LastResponse, selector);
-        }
-
-        public async Task AssertExistsAsync(HttpResponseMessage response, string selector)
-        {
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-            var html = await response.Content.ReadAsStringAsync();
-
-            var dom = new CQ(html);
-            var element = dom.Find(selector);
-            element.Length.Should().BeGreaterThan(0);
-        }
-
-        public Task AssertNotExistsAsync(string selector)
-        {
-            return AssertNotExistsAsync(selector);
-        }
-        public async Task AssertNotExistsAsync(HttpResponseMessage response, string selector)
-        {
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-            var html = await response.Content.ReadAsStringAsync();
-
-            var dom = new CQ(html);
-            var element = dom.Find(selector);
-            element.Length.Should().Be(0);
-        }
-
-        public Task AssertErrorPageAsync(string error = null)
-        {
-            return AssertErrorPageAsync(LastResponse, error);
-        }
-        public async Task AssertErrorPageAsync(HttpResponseMessage response, string error = null)
-        {
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            await AssertExistsAsync(response, ".error-page");
-
-            if (!String.IsNullOrWhiteSpace(error))
-            {
-                var errorText = await ReadElementTextAsync(response, ".alert.alert-danger");
-                errorText.Should().Contain(error);
-            }
-        }
-
-        public Task AssertValidationErrorAsync(string error = null)
-        {
-            return AssertValidationErrorAsync(error);
-        }
-        public async Task AssertValidationErrorAsync(HttpResponseMessage response, string error = null)
-        {
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            await AssertExistsAsync(response, ".validation-summary-errors");
-
-            if (!String.IsNullOrWhiteSpace(error))
-            {
-                var errorText = await ReadElementTextAsync(response, ".validation-summary-errors");
-                errorText.ToLowerInvariant().Should().Contain(error.ToLowerInvariant());
-            }
-        }
-    }
-
-    [DebuggerDisplay("{Action}, Inputs: {Inputs.Count}")]
-    public class HtmlForm
-    {
-        public HtmlForm(string action = null)
-        {
-            Action = action;
-        }
-
-        public string Action { get; set; }
-        public Dictionary<string, string> Inputs { get; set; } = new Dictionary<string, string>();
-
-        public string this[string key]
-        {
-            get
-            {
-                if (Inputs.ContainsKey(key)) return Inputs[key];
-                return null;
-            }
-            set
-            {
-                Inputs[key] = value;
             }
         }
     }


### PR DESCRIPTION
Removes CSQuery package reference fixing several compilation warnings regarding vulnerable transitive dependencies. Even though it was referenced in a test project. Also, CSQuery is not maintained.

Removed all code using CSQuery as none of it was used on any test path.

If we need HTML parsing in the future, we'll introduce AngleSharp.